### PR TITLE
move features on top

### DIFF
--- a/app/core/components/Features.tsx
+++ b/app/core/components/Features.tsx
@@ -26,11 +26,11 @@ const features = [
   },
 ]
 
-export const NotConvincedYet = () => {
+export const Features = () => {
   return (
-    <div id="feature-cols" className="flex flex-col lg:flex-row items-center mx-20">
+    <div id="feature-cols" className="flex flex-col lg:flex-row items-center m-6 max-w-5xl">
       <div id="feature-image" className="flex-1">
-        <h1 className="text-4xl self-center m-6">
+        <h1 className="text-3xl self-center m-6">
           Unlocking the power of community in science
         </h1>
         <Image

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -9,7 +9,7 @@ import EnterDOI from "../core/components/EnterDOI"
 import { Footer } from "app/core/components/Footer"
 import { Hero } from "app/core/components/Hero"
 import { HowItWorks } from "app/core/components/HowItWorks"
-import { NotConvincedYet } from "app/core/components/NotConvincedYet"
+import { Features } from "app/core/components/Features"
 import { SignUpButton } from "app/core/components/SignUpButton"
 import { Visions } from "app/core/components/Visions"
 
@@ -51,8 +51,8 @@ const Home: BlitzPage = () => {
         className="flex-grow flex flex-col items-center"
       >
         <Hero />
+        <Features />
         <HowItWorks />
-        <NotConvincedYet />
         <SignUpButton />
         <Visions />
         <div>


### PR DESCRIPTION
This PR moves the features information on the landing page on top, below the hero.

- rename NotConvincedYet to Features
- update component name
