### PR TITLE
fix reference to blitz module

### DIFF
--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, invoke } from "@blitzjs/core"
+import { useQuery, useMutation, invoke } from "blitz"
 import getReviewQuestions from "app/queries/getReviewQuestions"
 import getReviewAnswers from "app/queries/getReviewAnswers"
 import React, { useState } from "react"

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useQuery } from "@blitzjs/core"
+import { useQuery } from "blitz"
 import CircularProgress from "@mui/material/CircularProgress"
 import Box from "@mui/material/Box"
 import Typography from "@mui/material/Typography"

--- a/app/pages/articles/[articleId].tsx
+++ b/app/pages/articles/[articleId].tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, useParam, useQuery } from "@blitzjs/core"
+import { BlitzPage, useParam, useQuery } from "blitz"
 import Button from "@mui/material/Button"
 import Header from "app/core/components/Header"
 import { ReviewList } from "app/core/components/ReviewList"

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, useQuery } from "@blitzjs/core"
+import { BlitzPage, useQuery } from "blitz"
 import EditIcon from "@mui/icons-material/Edit"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import {


### PR DESCRIPTION
This PR fixes the reference to blitz as "blitz", rather than "@blitz". With the blitz.js update, import references are no longer "@blitz".