### PR TITLE
Use GOOGLE_CALLBACK_URL for OAuth strategy

### DIFF
--- a/app/api/auth/[...auth].ts
+++ b/app/api/auth/[...auth].ts
@@ -16,7 +16,7 @@ export default passportAuth({
             process.env.NODE_ENV === "production"
               ? // deployment target
                 "https://postreview-app.herokuapp.com/api/auth/google/callback"
-              : "http://localhost:3000/api/auth/google/callback",
+              : process.env.GOOGLE_CALLBACK_URL,
           scope: ["email", "profile"],
         },
         async function (_token, _tokenSecret, profile, done) {


### PR DESCRIPTION
This PR makes the google callback URL defined by an environmental variable so that I can use the strategy at local and also on Heroku.