### PR TITLE
add delete user

### DIFF
--- a/app/mutations/deleteUser.tsx
+++ b/app/mutations/deleteUser.tsx
@@ -1,0 +1,14 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+
+export default async function deleteUser(currentUserId, ctx: Ctx) {
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  const result = await db.user.delete({ where: { id: currentUserId } })
+
+  return result
+}

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -51,7 +51,7 @@ const Profile = () => {
     <div className="flex flex-col min-h-screen">
       <Header />
       <main className="flex-grow">
-        <div id="user-info-card" className="bg-gray-100 p-4">
+        <div id="user-info-card" className="bg-gray-200 p-4">
           <div className="flex flex-row items-center">
             <div id="user-icon-container" className="m-2">
               <AccountCircleIcon color="disabled" fontSize="large" />
@@ -110,14 +110,13 @@ const Profile = () => {
             <a href="#">Public profile view</a>
           </div>
           <Box>
-            <Button
-              variant="text"
-              className="m-6 focus:outline-none"
-              color="error"
+            <div
+              id="delete-account"
+              className="m-2 font-semibold hover:cursor-pointer text-red-400"
               onClick={openDeactivateAccountDialog}
             >
               Deactivate your account
-            </Button>
+            </div>
             <Dialog open={isDeactivateAccountDialogOpen} onClose={closeDeactivateAccountDialog}>
               <DialogTitle id="deactivate-account">{"Deactivating Your Account"}</DialogTitle>
               <DialogContent>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, invoke, useQuery, useRouter } from "blitz"
+import { BlitzPage, invoke, useMutation, useQuery, useRouter } from "blitz"
 import EditIcon from "@mui/icons-material/Edit"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import {
@@ -20,6 +20,7 @@ import { MyReviewsTable } from "app/core/components/MyReviewsTable"
 import { MyReviewsEmptyState } from "app/core/components/MyReviewsEmptyState"
 import { Footer } from "app/core/components/Footer"
 import deleteUser from "app/mutations/deleteUser"
+import logout from "app/auth/mutations/logout"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
@@ -43,8 +44,10 @@ const Profile = () => {
   }
 
   const router = useRouter()
+  const [logoutMutation] = useMutation(logout)
   const handleDeleteUser = async () => {
     await invoke(deleteUser, currentUser?.id)
+    await logoutMutation()
     router.push("/")
   }
 
@@ -116,14 +119,14 @@ const Profile = () => {
           <div id="public-view-container" className="m-2 text-blue-500 font-semibold">
             <a href="#">Public profile view</a>
           </div>
+          <div
+            id="delete-account"
+            className="m-2 font-semibold hover:cursor-pointer text-red-400"
+            onClick={openDeactivateAccountDialog}
+          >
+            Deactivate your account
+          </div>
           <Box>
-            <div
-              id="delete-account"
-              className="m-2 font-semibold hover:cursor-pointer text-red-400"
-              onClick={openDeactivateAccountDialog}
-            >
-              Deactivate your account
-            </div>
             <Dialog open={isDeactivateAccountDialogOpen} onClose={closeDeactivateAccountDialog}>
               <DialogTitle id="deactivate-account">{"Deactivating Your Account"}</DialogTitle>
               <DialogContent>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, useQuery } from "blitz"
+import { BlitzPage, invoke, useQuery, useRouter } from "blitz"
 import EditIcon from "@mui/icons-material/Edit"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import {
@@ -18,6 +18,7 @@ import { Suspense, useState } from "react"
 import { MyReviewsTable } from "app/core/components/MyReviewsTable"
 import { MyReviewsEmptyState } from "app/core/components/MyReviewsEmptyState"
 import { Footer } from "app/core/components/Footer"
+import deleteUser from "app/mutations/deleteUser"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
@@ -38,6 +39,12 @@ const Profile = () => {
   }
   const closeDeactivateAccountDialog = () => {
     setIsDeactivateAccountDialogOpen(false)
+  }
+
+  const router = useRouter()
+  const handleDeleteUser = async () => {
+    await invoke(deleteUser, currentUser?.id)
+    router.push("/")
   }
 
   return (
@@ -121,7 +128,7 @@ const Profile = () => {
                 <Button onClick={closeDeactivateAccountDialog} autoFocus>
                   Cancel
                 </Button>
-                <Button variant="contained" color="error" onClick={closeDeactivateAccountDialog}>
+                <Button variant="contained" color="error" onClick={handleDeleteUser}>
                   Deactivate
                 </Button>
               </DialogActions>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -2,6 +2,7 @@ import { BlitzPage, invoke, useQuery, useRouter } from "blitz"
 import EditIcon from "@mui/icons-material/Edit"
 import AccountCircleIcon from "@mui/icons-material/AccountCircle"
 import {
+  Avatar,
   Button,
   Dialog,
   DialogActions,
@@ -54,7 +55,13 @@ const Profile = () => {
         <div id="user-info-card" className="bg-gray-200 p-4">
           <div className="flex flex-row items-center">
             <div id="user-icon-container" className="m-2">
-              <AccountCircleIcon color="disabled" fontSize="large" />
+              <Button id="user-avatar" className="focus:outline-none" onClick={undefined}>
+                {currentUser?.icon ? (
+                  <Avatar alt={currentUser.handle} src={currentUser.icon!} />
+                ) : (
+                  <Avatar>{currentUser?.handle?.[0]}</Avatar>
+                )}
+              </Button>{" "}
             </div>
             <div id="handle-field-container">
               <TextField

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -47,8 +47,8 @@ const Profile = () => {
   const [logoutMutation] = useMutation(logout)
   const handleDeleteUser = async () => {
     await invoke(deleteUser, currentUser?.id)
-    await logoutMutation()
     router.push("/")
+    await logoutMutation()
   }
 
   return (

--- a/db/migrations/20220103135507_allow_null_for_added_by_id/migration.sql
+++ b/db/migrations/20220103135507_allow_null_for_added_by_id/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Article" DROP CONSTRAINT "Article_addedById_fkey";
+
+-- AlterTable
+ALTER TABLE "Article" ALTER COLUMN "addedById" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Article" ADD CONSTRAINT "Article_addedById_fkey" FOREIGN KEY ("addedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/db/migrations/20220103135734_allow_null_user_for_review_answers/migration.sql
+++ b/db/migrations/20220103135734_allow_null_user_for_review_answers/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "ReviewAnswers" DROP CONSTRAINT "ReviewAnswers_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "ReviewAnswers" ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "ReviewAnswers" ADD CONSTRAINT "ReviewAnswers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/db/migrations/20220104111659_cascading_delete/migration.sql
+++ b/db/migrations/20220104111659_cascading_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "ReviewAnswers" DROP CONSTRAINT "ReviewAnswers_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ReviewAnswers" ADD CONSTRAINT "ReviewAnswers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -75,7 +75,7 @@ model Article {
   id            String          @id @default(uuid())
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
-  addedBy       User?           @relation(fields: [addedById], references: [id])
+  addedBy       User?           @relation(fields: [addedById], references: [id], onDelete: SetNull)
   addedById     Int?
   doi           String          @unique
   title         String
@@ -96,7 +96,7 @@ model Author {
   affiliation String?
   Article     Article? @relation(fields: [articleId], references: [id])
   articleId   String?
-  User        User?    @relation(fields: [userId], references: [id])
+  User        User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
   userId      Int?
 }
 
@@ -104,7 +104,7 @@ model ReviewAnswers {
   id            Int             @id @default(autoincrement())
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
-  writtenBy     User?           @relation(fields: [userId], references: [id])
+  writtenBy     User?           @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   targetArticle Article?        @relation(fields: [articleId], references: [id])
   userId        Int?
   articleId     String

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -104,9 +104,9 @@ model ReviewAnswers {
   id            Int             @id @default(autoincrement())
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
-  writtenBy     User            @relation(fields: [userId], references: [id])
+  writtenBy     User?           @relation(fields: [userId], references: [id])
   targetArticle Article?        @relation(fields: [articleId], references: [id])
-  userId        Int
+  userId        Int?
   articleId     String
   question      ReviewQuestions @relation(fields: [questionId], references: [questionId])
   response      Int

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -76,7 +76,7 @@ model Article {
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
   addedBy       User?           @relation(fields: [addedById], references: [id])
-  addedById     Int
+  addedById     Int?
   doi           String          @unique
   title         String
   publishedYear Int

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -75,7 +75,7 @@ model Article {
   id            String          @id @default(uuid())
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
-  addedBy       User            @relation(fields: [addedById], references: [id])
+  addedBy       User?           @relation(fields: [addedById], references: [id])
   addedById     Int
   doi           String          @unique
   title         String


### PR DESCRIPTION
This PR adds a function to delete one's own account.

I'm using cascading delete here for review answers--so that people's reviews will be deleted as they delete their account. All the articles posted by a user will remain in the database, and the user field will be null.

- Make "addedBy" optional to allow null
- Add deleteUser mutation
- Add deleteUser to Profile
- Change the deactivate button
- Add Avatar to Profile
- Allow null for addedByID
- DB Migration
- Allow null user for ReviewAnswers
- db migration
- Cascade only for reviews, not for articles
- Bring out delete-account from Box
- Add logout mutation after deleteUser
