### PR TITLE
Change query to return only articles with user reviews

### DIFF
--- a/app/queries/getReviewAnswersByUserId.tsx
+++ b/app/queries/getReviewAnswersByUserId.tsx
@@ -5,6 +5,7 @@ export default async function getReviewAnswersByUserId(props) {
   return await db.article.findMany({
     where: {
       review: {
+        some: {},
         every: {
           userId: currentUserId,
         },


### PR DESCRIPTION
This PR fixes #53, the issue about the profile page showing articles without reviews. I fixed it using `some: {}` ([reference](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries)).