### PR TITLE
67 Fix Duplicate Summary Scores

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -11,7 +11,7 @@ export default function Article(props) {
   const { id, authorString, doi, title, disabled, usersWithReview } = props
 
   const [articleScores] = useQuery(getArticleScoresById, {
-    currentArticleId: id,
+    articleId: id,
   })
 
   const [questionCategories] = useQuery(getQuestionCategories, undefined)

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -39,7 +39,7 @@ export default function Article(props) {
               <FaUser className="inline mr-2" />
               {authorString}
             </div>
-            <div className="article__DOI ml-2 text-gray-700">
+            <div className="article__DOI ml-2 text-gray-700 whitespace-nowrap">
               <a rel="noreferrer" target="_blank">
                 <FaBook className="inline mr-2" />
                 <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -42,7 +42,9 @@ export default function Article(props) {
             <div className="article__DOI ml-2 text-gray-700">
               <a rel="noreferrer" target="_blank">
                 <FaBook className="inline mr-2" />
-                {doi}
+                <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">
+                  {doi}
+                </a>
               </a>
             </div>
           </div>

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -8,7 +8,7 @@ import getArticleScoresById from "app/queries/getArticleScoresById"
 import getQuestionCategories from "app/queries/getQuestionCategories"
 
 export default function Article(props) {
-  const { id, authorString, doi, title, disabled, usersWithReview } = props
+  const { id, authorString, doi, title } = props
 
   const [articleScores] = useQuery(getArticleScoresById, {
     articleId: id,


### PR DESCRIPTION
This PR fixes #67. The problem was that the props for the getArticleScoresById query had the wrong argument (and thus querying multiple articles).

I also fixed #71 by making the DOI clickable. Along the way, I made the DOI line not break (via Tailwind, `whitespace-nowrap`)

- Make DOI clickable (fix 71)
- Fix key for the getArticleScoresByID
- Cleanup
- Do not wrap the DOI string and the icon
