### PR TITLE
88 Fix duplicate ratings on profile & article page

### DIFF
--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -34,7 +34,10 @@ export const MyReviewsTable = (props) => {
               <div className="text-sm text-gray-500">{article.doi}</div>
             </div>
             <div id="review-metadata" className="text-xs">
-              <div id="submitter">Submitted by: {currentUser.name}</div>
+              <div id="submitter">
+                Submitted by:{" "}
+                {currentUser.displayName ? currentUser.displayName : currentUser.handle}
+              </div>
               <div id="submitted-on">
                 Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}
               </div>

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { useQuery } from "blitz"
 import { useCurrentUser } from "../hooks/useCurrentUser"
-import getReviewAnswers from "app/queries/getReviewAnswers"
+import getUssersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByArticleId"
 import { Review } from "./Review"
 
 export const ReviewList = (prop) => {
   const { article } = prop
   const currentUser = useCurrentUser()
 
-  const [usersWithReview] = useQuery(getReviewAnswers, {
+  const [usersWithReview] = useQuery(getUssersWithReviewsByArticleId, {
     currentArticleId: article?.id,
   })
 

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -14,7 +14,7 @@ import {
 import { Box } from "@mui/system"
 import Header from "app/core/components/Header"
 import { useCurrentUser } from "app/core/hooks/useCurrentUser"
-import getArticleWithReviewByUserId from "app/queries/getReviewAnswersByUserId"
+import getReviewAnswersByUserId from "app/queries/getReviewAnswersByUserId"
 import { Suspense, useState } from "react"
 import { MyReviewsTable } from "app/core/components/MyReviewsTable"
 import { MyReviewsEmptyState } from "app/core/components/MyReviewsEmptyState"
@@ -24,7 +24,7 @@ import logout from "app/auth/mutations/logout"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
-  const [articleWithReview] = useQuery(getArticleWithReviewByUserId, currentUser?.id)
+  const [articleWithReview] = useQuery(getReviewAnswersByUserId, { currentUserId: currentUser?.id })
   const [handleDisabled, setHandleDisabled] = useState(true)
   const [isDeactivateAccountDialogOpen, setIsDeactivateAccountDialogOpen] = useState(false)
   const changeHandle = () => {

--- a/app/queries/getReviewAnswersByUserId.tsx
+++ b/app/queries/getReviewAnswersByUserId.tsx
@@ -6,13 +6,11 @@ export default async function getReviewAnswersByUserId(props) {
     where: {
       review: {
         some: {},
-        every: {
-          userId: currentUserId,
-        },
       },
     },
     include: {
       review: {
+        where: { userId: currentUserId },
         include: {
           question: true,
         },

--- a/app/queries/getUsersWithReviewsByArticleId.tsx
+++ b/app/queries/getUsersWithReviewsByArticleId.tsx
@@ -1,0 +1,26 @@
+import db from "db"
+
+export default async function getUssersWithReviewsByArticleId(props) {
+  const { currentArticleId } = props
+  return await db.user.findMany({
+    where: {
+      review: {
+        some: {
+          articleId: currentArticleId,
+        },
+      },
+    },
+    select: {
+      id: true,
+      handle: true,
+      displayName: true,
+      icon: true,
+      review: {
+        where: { articleId: currentArticleId },
+        include: {
+          question: true,
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
This PR fixes the issue of duplicate ratings appearing on profiles (Issue #88). 
I also fixed an unreported issue on duplicate ratings appearing on the article page.

- Fix article page reviews rendering
- Update query on profile to filter by user id
- Show handle if displayname is not set
