### PR TITLE
75 Remove Empty State from the Profile Page

### DIFF
--- a/app/core/components/MyReviewsEmptyState.tsx
+++ b/app/core/components/MyReviewsEmptyState.tsx
@@ -4,18 +4,15 @@ import PostAddIcon from "@mui/icons-material/PostAdd"
 export const MyReviewsEmptyState = () => {
   return (
     <div>
-      <div className="text-gray-500">No ratings submitted yet.</div>
-
       <div
-        className="bg-gray-50 m-6 p-4 border-gray-600 border-2 border-dashed
-    flex flex-col  max-w-5xl"
+        className="bg-gray-50 m-6 p-4 border-gray-500 border-2 border-dashed
+    flex flex-col  max-w-5xl h-32 justify-center"
       >
-        <a href="#" className="self-center">
-          <div className="flex flex-col items-center">
-            <PostAddIcon fontSize="large" color="action" />
-            <div id="rate-paper-container">Rate a paper</div>
+        <div className="flex flex-col items-center">
+          <div id="rate-paper-container" className="text-gray-500">
+            No ratings have been submitted yet
           </div>
-        </a>
+        </div>
       </div>
     </div>
   )

--- a/app/core/components/RatePaperEmptyState.tsx
+++ b/app/core/components/RatePaperEmptyState.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import PostAddIcon from "@mui/icons-material/PostAdd"
+
+export const RatePaperEmptyState = () => {
+  return (
+    <div
+      className="bg-gray-50 m-6 p-4 border-gray-600 border-2 border-dashed
+    flex flex-col  max-w-5xl"
+    >
+      <a href="#" className="self-center">
+        <div className="flex flex-col items-center">
+          <PostAddIcon fontSize="large" color="action" />
+          <div id="rate-paper-container">Rate a paper</div>
+        </div>
+      </a>
+    </div>
+  )
+}

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -24,7 +24,9 @@ import logout from "app/auth/mutations/logout"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
-  const [articleWithReview] = useQuery(getReviewAnswersByUserId, { currentUserId: currentUser?.id })
+  const [myArticlesWithReview] = useQuery(getReviewAnswersByUserId, {
+    currentUserId: currentUser?.id,
+  })
   const [handleDisabled, setHandleDisabled] = useState(true)
   const [isDeactivateAccountDialogOpen, setIsDeactivateAccountDialogOpen] = useState(false)
   const changeHandle = () => {
@@ -111,8 +113,8 @@ const Profile = () => {
         <div id="my-reviews-container" className="m-3">
           <h1 className="text-3xl">Reviews You Posted</h1>
           <div className="m-6">
-            {articleWithReview.length === 0 && <MyReviewsEmptyState />}
-            <MyReviewsTable articleWithReview={articleWithReview} currentUser={currentUser} />
+            {myArticlesWithReview.length === 0 && <MyReviewsEmptyState />}
+            <MyReviewsTable articleWithReview={myArticlesWithReview} currentUser={currentUser} />
           </div>
         </div>
         <div>

--- a/app/queries/getReviewAnswersByUserId.tsx
+++ b/app/queries/getReviewAnswersByUserId.tsx
@@ -5,7 +5,7 @@ export default async function getReviewAnswersByUserId(props) {
   return await db.article.findMany({
     where: {
       review: {
-        some: {},
+        some: { userId: currentUserId },
       },
     },
     include: {


### PR DESCRIPTION
This PR removes an empty state ("Rate a Paper") from the profile page (fixes #75). 

Along the way, I also fixed a bug where I was seeing an article with a review on my profile, although I don't have reviews.

- Rename object for articles with review for a given user
- Make the query results null for articles without reviews
- Create an empty state for rate a paper
- Remove rate a paper from profile empty state
