### PR TITLE
#87 Fix the review update process (modifying and updating reviews)

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -40,11 +40,9 @@ export default function Article(props) {
               {authorString}
             </div>
             <div className="article__DOI ml-2 text-gray-700 whitespace-nowrap">
-              <a rel="noreferrer" target="_blank">
+              <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">
                 <FaBook className="inline mr-2" />
-                <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">
-                  {doi}
-                </a>
+                {doi}
               </a>
             </div>
           </div>

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -41,7 +41,7 @@ export default function PopupReview(prop) {
   const [addReviewMutation] = useMutation(addReview)
   const handleReviewSubmit = async () => {
     setLoading(true)
-    await invoke(addReviewMutation, [...reviewAnswersToDb])
+    await invoke(addReviewMutation, reviewAnswersToDb)
     setUserHasReview(true)
     window.location.reload()
   }

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -11,7 +11,7 @@ import { DialogActions, DialogContent, DialogTitle, Switch, Tooltip } from "@mui
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
 
 export default function PopupReview(prop) {
-  const { article, handleClose, setUserHasReview } = prop
+  const { article, handleClose, setUserHasReview, setIsChangeMade } = prop
   const [reviewQuestions] = useQuery(getReviewQuestions, undefined)
   const currentUser = useCurrentUser()
   const reviewAnswerQueryParams = {
@@ -28,8 +28,6 @@ export default function PopupReview(prop) {
     if (isAnonymous) setIsAnonymous(false)
     if (!isAnonymous) setIsAnonymous(true)
   }
-
-  const defaultUserHasReview = !!defaultReviewAnswers?.length
 
   const updateRating = (questionId, newRating) => {
     const newAnswers = [...reviewAnswers]
@@ -69,6 +67,7 @@ export default function PopupReview(prop) {
                 question={question}
                 onReviewUpdate={updateRating}
                 reviewAnswers={reviewAnswers}
+                setIsChangeMade={setIsChangeMade}
               />
             )
           })}

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -68,6 +68,7 @@ export default function PopupReview(prop) {
                 key={question?.questionId}
                 question={question}
                 onReviewUpdate={updateRating}
+                reviewAnswers={reviewAnswers}
               />
             )
           })}

--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -1,10 +1,9 @@
 import React from "react"
-import Button from "@mui/material/Button"
 import Rating from "@mui/material/Rating"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 
 export const ReviewQuestion = (props) => {
-  const { article, question, onReviewUpdate } = props
+  const { article, question, onReviewUpdate, reviewAnswers } = props
   const currentUser = useCurrentUser()
   const handleRatingChange = (questionId, newValue) => {
     const newData = {
@@ -15,6 +14,8 @@ export const ReviewQuestion = (props) => {
     }
     onReviewUpdate(questionId, newData)
   }
+  const currentAnswer = reviewAnswers.find((answer) => answer.questionId == question.questionId)
+
   return (
     <div
       className="
@@ -48,6 +49,7 @@ export const ReviewQuestion = (props) => {
             onChange={(event, newValue) => {
               handleRatingChange(question.questionId, newValue)
             }}
+            value={currentAnswer.response}
           />
         </div>
         <div

--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -49,7 +49,7 @@ export const ReviewQuestion = (props) => {
             onChange={(event, newValue) => {
               handleRatingChange(question.questionId, newValue)
             }}
-            value={currentAnswer.response}
+            value={currentAnswer?.response}
           />
         </div>
         <div

--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -3,7 +3,7 @@ import Rating from "@mui/material/Rating"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 
 export const ReviewQuestion = (props) => {
-  const { article, question, onReviewUpdate, reviewAnswers } = props
+  const { article, question, onReviewUpdate, reviewAnswers, setIsChangeMade } = props
   const currentUser = useCurrentUser()
   const handleRatingChange = (questionId, newValue) => {
     const newData = {
@@ -48,6 +48,7 @@ export const ReviewQuestion = (props) => {
             max={question.maxValue}
             onChange={(event, newValue) => {
               handleRatingChange(question.questionId, newValue)
+              setIsChangeMade(true)
             }}
             value={currentAnswer?.response}
           />

--- a/app/pages/articles/[articleId].tsx
+++ b/app/pages/articles/[articleId].tsx
@@ -24,7 +24,9 @@ const ArticleDetails = () => {
   const openReviewDialog = () => {
     setIsReviewDialogOpen(true)
   }
+  const [isChangeMade, setIsChangeMade] = useState(false)
   const closeReviewDialog = () => {
+    if (!isChangeMade) return setIsReviewDialogOpen(false)
     setIsConfirmDialogOpen(true)
   }
   const handleConfirmDiscard = () => {
@@ -67,6 +69,7 @@ const ArticleDetails = () => {
             article={article}
             handleClose={closeReviewDialog}
             setUserHasReview={setUserHasReview}
+            setIsChangeMade={setIsChangeMade}
           />
         </Dialog>
         <Dialog open={isConfirmDialogOpen} onClose={closeConfirmDialog}>

--- a/app/queries/getReviewAnswersByArticleAndUserIds.tsx
+++ b/app/queries/getReviewAnswersByArticleAndUserIds.tsx
@@ -4,7 +4,7 @@ export default async function getReviewAnswersByArticleAndUserIds(props) {
   const { currentArticleId, currentUserId } = props
   return await db.reviewAnswers.findMany({
     where: {
-      id: currentUserId,
+      userId: currentUserId,
       articleId: currentArticleId,
     },
   })


### PR DESCRIPTION
This PR adds the functionality of modifying and updating reviews. Also, it subsequently fixes the infinite loading animation issue. Fixes #87 & #86 

Along the way, I also changed how the confirmation dialog is displayed for canceling out the review submission. Now, the confirmation window will only show up when the user clicked on the stars.

- Fix passing of user id to query
- Show existing review answers
- Make the rating value optional
- Use upsert for updating the reviews
- Hide the confirmation dialog if no change was made
- Fix nested a tag error
