### PR TITLE
95 Show placeholders (N/A) when reviews are missing 

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -55,41 +55,77 @@ export default function Article(props) {
       >
         <div id="total" className="px-3 border-r-2 text-center">
           <div id="total-rating">
-            <Rating
-              readOnly
-              defaultValue={totalRating / 5}
-              precision={0.1}
-              max={1}
-              sx={{
-                fontSize: 100,
-                color: "#FF5733",
-              }}
-              emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
-            />
+            {ratingsCount === 0 ? ( // When no ratings, show a placeholder
+              <div className="flex items-center justify-center">
+                <div className="absolute text-gray-500 z-50">N/A</div>
+                <Rating
+                  readOnly
+                  value={0}
+                  precision={0.1}
+                  max={1}
+                  sx={{
+                    fontSize: 100,
+                    color: "#FF5733",
+                  }}
+                  emptyIcon={<StarIcon style={{ opacity: 0.2 }} fontSize="inherit" />}
+                />
+              </div>
+            ) : (
+              <Rating
+                readOnly
+                value={totalRating / 5}
+                precision={0.1}
+                max={1}
+                sx={{
+                  fontSize: 100,
+                  color: "#FF5733",
+                }}
+                emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+              />
+            )}
           </div>
           Total
         </div>
-        {articleScores.map((score) => (
-          <div key={score.questionId} className="text-center">
-            <Rating
-              readOnly
-              defaultValue={score._avg.response! / 5}
-              precision={0.1}
-              max={1}
-              sx={{
-                fontSize: 100,
-                color: "#FFC300",
-              }}
-              emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
-            />
-            <div>
-              {
-                questionCategories.find((category) => category.questionId === score.questionId)
-                  ?.questionCategory
-              }
+        {questionCategories.map((category) =>
+          articleScores.find((score) => score.questionId === category.questionId)?._avg
+            .response! ? (
+            <div key={category.questionId} className="text-center">
+              <Rating
+                readOnly
+                value={
+                  articleScores.find((score) => score.questionId === category.questionId)?._avg
+                    .response! / 5
+                }
+                precision={0.1}
+                max={1}
+                sx={{
+                  fontSize: 100,
+                  color: "#FFC300",
+                }}
+                emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+              />
+              <div>{category.questionCategory}</div>
             </div>
-          </div>
-        ))}
+          ) : (
+            <div key={category.questionId} className="text-center">
+              <div className="flex items-center justify-center">
+                <div className="absolute text-gray-500 z-50">N/A</div>
+                <Rating
+                  readOnly
+                  value={0}
+                  precision={0.1}
+                  max={1}
+                  sx={{
+                    fontSize: 100,
+                    color: "#FF5733",
+                  }}
+                  emptyIcon={<StarIcon style={{ opacity: 0.2 }} fontSize="inherit" />}
+                />
+              </div>
+              <div>{category.questionCategory}</div>
+            </div>
+          )
+        )}
       </div>
     </div>
   )

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -1,10 +1,13 @@
 import { Rating } from "@mui/material"
 import React from "react"
 import { styled } from "@mui/material/styles"
+import { ReviewStars } from "./ReviewStars"
+import { useQuery } from "blitz"
+import getQuestionCategories from "app/queries/getQuestionCategories"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
-  const ratingScaleMax = 5
+  const [questionCategories] = useQuery(getQuestionCategories, undefined)
 
   const RatingTotal = styled(Rating)({
     "& .MuiRating-iconFilled": {
@@ -50,28 +53,7 @@ export const MyReviewsTable = (props) => {
             id="ratings-container"
             className="flex lg:flex-row flex-col items-center justify-evenly text-xs mx-6"
           >
-            <div id="total" className="px-3 border-r-2 text-center">
-              Total
-              <div id="total-rating">
-                <RatingTotal
-                  size="small"
-                  readOnly
-                  max={ratingScaleMax}
-                  value={
-                    article.review.reduce((prev, current) => prev + current.response, 0) /
-                    article.review.length
-                  }
-                />
-              </div>
-            </div>
-            {article.review.map((answer) => (
-              <div key={answer.id} className="m-2 text-center">
-                {answer.question.questionCategory}
-                <div id="rating">
-                  <Rating size="small" readOnly max={ratingScaleMax} value={answer.response} />
-                </div>
-              </div>
-            ))}
+            <ReviewStars reviews={article.review} questionCategories={questionCategories} />
           </div>
         </div>
       ))}

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -1,7 +1,6 @@
 import { Avatar, Button, Tooltip } from "@mui/material"
 import React from "react"
-import { RatingTotal } from "./RatingTotal"
-import { ReviewCategoryAnswer } from "./ReviewCategoryAnswer"
+import { ReviewStars } from "./ReviewStars"
 
 export const Review = (props) => {
   const { displayName, reviews, userIcon, questionCategories } = props
@@ -30,44 +29,11 @@ export const Review = (props) => {
         className="bg-gray-50 p-4 border-gray-600 border-2
           flex flex-col  max-w-5xl"
       >
-        <div
-          id="ratings-container"
-          className="flex lg:flex-row flex-col items-center justify-evenly text-xs mx-6"
-        >
-          <div id="total" className="px-3 border-r-2 text-center">
-            Total
-            <div id="total-rating">
-              <RatingTotal
-                size="small"
-                readOnly
-                max={ratingScaleMax}
-                value={
-                  reviews.reduce((prev, current) => prev + current.response, 0) / reviews.length
-                }
-              />
-            </div>
-          </div>
-          {questionCategories.map((category) => {
-            const currentReview = reviews.find(
-              (review) => review.questionId === category.questionId
-            )
-            return currentReview ? (
-              <ReviewCategoryAnswer
-                key={currentReview.id}
-                ratingScaleMax={5}
-                response={currentReview.response}
-                questionCategory={currentReview.question.questionCategory}
-              />
-            ) : (
-              <ReviewCategoryAnswer
-                key={category.id}
-                ratingScaleMax={5}
-                norating
-                questionCategory={category.questionCategory}
-              />
-            )
-          })}
-        </div>
+        <ReviewStars
+          ratingScaleMax={ratingScaleMax}
+          reviews={reviews}
+          questionCategories={questionCategories}
+        />
       </div>
     </div>
   )

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -6,7 +6,6 @@ export const Review = (props) => {
   const { displayName, reviews, userIcon, questionCategories } = props
   const submittedAt = reviews[0]?.createdAt?.toISOString().split("T")[0]
   const updatedAt = reviews[0]?.updatedAt.toISOString().split("T")[0]
-  const ratingScaleMax = 5
   const isAnonymous = reviews[0]?.isAnonymous
   const submittedBy = isAnonymous ? "Anonymous" : displayName
   const submittedByIcon = userIcon
@@ -29,11 +28,7 @@ export const Review = (props) => {
         className="bg-gray-50 p-4 border-gray-600 border-2
           flex flex-col  max-w-5xl"
       >
-        <ReviewStars
-          ratingScaleMax={ratingScaleMax}
-          reviews={reviews}
-          questionCategories={questionCategories}
-        />
+        <ReviewStars reviews={reviews} questionCategories={questionCategories} />
       </div>
     </div>
   )

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -4,7 +4,7 @@ import { RatingTotal } from "./RatingTotal"
 import { ReviewCategoryAnswer } from "./ReviewCategoryAnswer"
 
 export const Review = (props) => {
-  const { handle, displayName, reviews, userIcon } = props
+  const { displayName, reviews, userIcon, questionCategories } = props
   const submittedAt = reviews[0]?.createdAt?.toISOString().split("T")[0]
   const updatedAt = reviews[0]?.updatedAt.toISOString().split("T")[0]
   const ratingScaleMax = 5
@@ -47,14 +47,26 @@ export const Review = (props) => {
               />
             </div>
           </div>
-          {reviews.map((review) => (
-            <ReviewCategoryAnswer
-              key={review.id}
-              ratingScaleMax={5}
-              response={review.response}
-              questionCategory={review.question.questionCategory}
-            />
-          ))}
+          {questionCategories.map((category) => {
+            const currentReview = reviews.find(
+              (review) => review.questionId === category.questionId
+            )
+            return currentReview ? (
+              <ReviewCategoryAnswer
+                key={currentReview.id}
+                ratingScaleMax={5}
+                response={currentReview.response}
+                questionCategory={currentReview.question.questionCategory}
+              />
+            ) : (
+              <ReviewCategoryAnswer
+                key={category.id}
+                ratingScaleMax={5}
+                norating
+                questionCategory={category.questionCategory}
+              />
+            )
+          })}
         </div>
       </div>
     </div>

--- a/app/core/components/ReviewCategoryAnswer.tsx
+++ b/app/core/components/ReviewCategoryAnswer.tsx
@@ -7,7 +7,7 @@ export const ReviewCategoryAnswer = (props) => {
   return norating ? (
     <div className="m-2 text-center">
       {questionCategory}
-      <div id="rating" className="text-gray-500 font-semibold text-sm mb-1">
+      <div id="rating" className="text-gray-500 text-sm mb-1 mx-8">
         N/A
       </div>
     </div>

--- a/app/core/components/ReviewCategoryAnswer.tsx
+++ b/app/core/components/ReviewCategoryAnswer.tsx
@@ -2,9 +2,16 @@ import { Rating } from "@mui/material"
 import React from "react"
 
 export const ReviewCategoryAnswer = (props) => {
-  const { questionCategory, ratingScaleMax, response } = props
+  const { questionCategory, ratingScaleMax, response, norating } = props
 
-  return (
+  return norating ? (
+    <div className="m-2 text-center">
+      {questionCategory}
+      <div id="rating" className="text-gray-500 font-semibold text-sm mb-1">
+        N/A
+      </div>
+    </div>
+  ) : (
     <div className="m-2 text-center">
       {questionCategory}
       <div id="rating">

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "blitz"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 import getUssersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByArticleId"
 import { Review } from "./Review"
+import getQuestionCategories from "app/queries/getQuestionCategories"
 
 export const ReviewList = (prop) => {
   const { article } = prop
@@ -11,6 +12,8 @@ export const ReviewList = (prop) => {
   const [usersWithReview] = useQuery(getUssersWithReviewsByArticleId, {
     currentArticleId: article?.id,
   })
+
+  const [questionCategories] = useQuery(getQuestionCategories, undefined)
 
   const currentUserReview = usersWithReview.find((user) => user.id == currentUser?.id)
   const currentUserHasReview = currentUserReview?.review.length
@@ -31,6 +34,7 @@ export const ReviewList = (prop) => {
                 handle={currentUserReview?.handle}
                 reviews={currentUserReview?.review}
                 userIcon={currentUserReview?.icon}
+                questionCategories={questionCategories}
               />
             ) : (
               <div className="m-20">Submit your review</div>
@@ -48,6 +52,7 @@ export const ReviewList = (prop) => {
                 displayName={user.handle}
                 handle={user.handle}
                 reviews={user.review}
+                questionCategories={questionCategories}
               />
             ))
           ) : (

--- a/app/core/components/ReviewStars.tsx
+++ b/app/core/components/ReviewStars.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { RatingTotal } from "./RatingTotal"
+import { ReviewCategoryAnswer } from "./ReviewCategoryAnswer"
+
+export const ReviewStars = (props) => {
+  const { ratingScaleMax, reviews, questionCategories } = props
+  return (
+    <div
+      id="ratings-container"
+      className="flex lg:flex-row flex-col items-center justify-evenly text-xs mx-6"
+    >
+      <div id="total" className="px-3 border-r-2 text-center">
+        Total
+        <div id="total-rating">
+          <RatingTotal
+            size="small"
+            readOnly
+            max={ratingScaleMax}
+            value={reviews.reduce((prev, current) => prev + current.response, 0) / reviews.length}
+          />
+        </div>
+      </div>
+      {questionCategories.map((category) => {
+        const currentReview = reviews.find((review) => review.questionId === category.questionId)
+        return currentReview ? (
+          <ReviewCategoryAnswer
+            key={currentReview.id}
+            ratingScaleMax={5}
+            response={currentReview.response}
+            questionCategory={currentReview.question.questionCategory}
+          />
+        ) : (
+          <ReviewCategoryAnswer
+            key={category.id}
+            ratingScaleMax={5}
+            norating
+            questionCategory={category.questionCategory}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/app/core/components/ReviewStars.tsx
+++ b/app/core/components/ReviewStars.tsx
@@ -3,7 +3,9 @@ import { RatingTotal } from "./RatingTotal"
 import { ReviewCategoryAnswer } from "./ReviewCategoryAnswer"
 
 export const ReviewStars = (props) => {
-  const { ratingScaleMax, reviews, questionCategories } = props
+  const { reviews, questionCategories } = props
+  const ratingScaleMax = 5
+
   return (
     <div
       id="ratings-container"
@@ -25,14 +27,14 @@ export const ReviewStars = (props) => {
         return currentReview ? (
           <ReviewCategoryAnswer
             key={currentReview.id}
-            ratingScaleMax={5}
+            ratingScaleMax={category.maxValue}
             response={currentReview.response}
             questionCategory={currentReview.question.questionCategory}
           />
         ) : (
           <ReviewCategoryAnswer
             key={category.id}
-            ratingScaleMax={5}
+            ratingScaleMax={category.maxValue}
             norating
             questionCategory={category.questionCategory}
           />


### PR DESCRIPTION
This PR will add N/A's when there are no reviews. On the article card, we show N/A on top of an empty star. On the review card, we show the text "N/A".

I separated stars rendering individual reviews as another component so that I can use them across the article page and the profile page.

Fix #95 

- Add N/A to stars without rating in `Article` card
- Map over question categories to render reviews
- Add `N/A` to the review card
- Query and pass question categories
- Separate `ReviewStars` component
- Get the max value from question categories
- Separate review stars into another compoennt
- Remove setting the max value at the review card level
- Change horizontal margin and fontface of "N/A"
