### PR TITLE
73 Fix the missing journal error when adding a paper

### DIFF
--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -33,7 +33,7 @@ export default function EnterDOI() {
       title: newArticleMetadata.title[0],
       doi: newArticleMetadata.DOI,
       publishedYear: newArticleMetadata.created["date-parts"][0][0],
-      journal: newArticleMetadata["short-container-title"][0],
+      journal: newArticleMetadata["container-title"][0],
       addedBy: currentUser?.handle,
       addedById: currentUser?.id,
       authorString: newArticleMetadata.author
@@ -55,6 +55,7 @@ export default function EnterDOI() {
     const newArticleMetadata = await getArticleMetadata()
     if (!newArticleMetadata) return null
     const newArticle = await parseArticleMetadata(newArticleMetadata)
+    console.log(newArticleMetadata)
     // Is article already in the database?
     const existingArticle = await invoke(getArticleByDoi, newArticle.doi)
     if (existingArticle) return router.push("/articles/" + existingArticle.id)

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -45,7 +45,8 @@ export default function EnterDOI() {
             return `${author.family}, ${author.given}; `
           }
         })
-        .toString(),
+        .toString()
+        .replace(/,/g, ""),
     }
     return newArticle
   }

--- a/app/core/components/EnterDOI.tsx
+++ b/app/core/components/EnterDOI.tsx
@@ -45,8 +45,7 @@ export default function EnterDOI() {
             return `${author.family}, ${author.given}; `
           }
         })
-        .toString()
-        .replace(/,/g, ""),
+        .join(""),
     }
     return newArticle
   }
@@ -56,7 +55,6 @@ export default function EnterDOI() {
     const newArticleMetadata = await getArticleMetadata()
     if (!newArticleMetadata) return null
     const newArticle = await parseArticleMetadata(newArticleMetadata)
-    console.log(newArticleMetadata)
     // Is article already in the database?
     const existingArticle = await invoke(getArticleByDoi, newArticle.doi)
     if (existingArticle) return router.push("/articles/" + existingArticle.id)


### PR DESCRIPTION
This PR fixes the issue where we cannot add a paper for missing a journal title (fix #73). The cause of the problem was that some article metadata do not have `short-container-title`.

This PR also fixes the issue of author names appearing with extra commas (fix #66). This was because of the `.toString` adding commas between array elements. I changed it to `.join("")` to avoid this behavior. In the future, it's better to have a separate table for article authors for lookup, etc. 

- Get journal title from `container-title`
- Remove automatically generated commas in authors
