### PR TITLE
Add DOI and author info to the header of the review popup

### DIFF
--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -9,6 +9,7 @@ import addReview from "app/mutations/addReview"
 import getReviewAnswersByArticleAndUserIds from "app/queries/getReviewAnswersByArticleAndUserIds"
 import { DialogActions, DialogContent, DialogTitle, Switch, Tooltip } from "@mui/material"
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
+import { FaBook, FaUser } from "react-icons/fa"
 
 export default function PopupReview(prop) {
   const { article, handleClose, setUserHasReview, setIsChangeMade } = prop
@@ -54,8 +55,16 @@ export default function PopupReview(prop) {
       </DialogTitle>
       <DialogContent>
         <div id="title-container" className="text-center">
+          <strong>{article.title} </strong>
+          <div>
+            <FaUser className="inline mr-2 text-gray-700" /> {article.authorString} (
+            {article.publishedYear})
+          </div>
           <a href={`https://doi.org/${article.doi}`} target="_blank" rel="noreferrer">
-            <strong>{article.title} </strong>
+            <div className="text-violet-600">
+              <FaBook className="inline mr-2" />
+              {`https://doi.org/${article.doi}`}
+            </div>
           </a>
         </div>
         <div id="question-container" className="flex flex-col">


### PR DESCRIPTION
This PR adds DOI to the review popup and makes it obvious that it's clickable (fixes #80).  Along the way:
- I removed the link from the title itself (since we now have the clickable DOI)
- I added the year of the publication after the author (I'm guessing many researchers would identify papers based on the combination of the author and the publication year)

<img width="725" alt="image" src="https://user-images.githubusercontent.com/17035406/153596709-2f4cbae4-a245-4b49-abc8-b197617f44d3.png">

@coglebed I'm curious to hear what you think about this design