### PR TITLE
Update the action menu for the reviews on the profile page

### DIFF
--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -15,7 +15,7 @@ import { styled } from "@mui/material/styles"
 import { ReviewStars } from "./ReviewStars"
 import { invoke, useQuery, useRouter } from "blitz"
 import getQuestionCategories from "app/queries/getQuestionCategories"
-import { MoreHoriz } from "@mui/icons-material"
+import { MoreHoriz, VisibilityOff } from "@mui/icons-material"
 import deleteReview from "app/mutations/deleteReview"
 
 export const MyReviewsTable = (props) => {
@@ -61,7 +61,8 @@ export const MyReviewsTable = (props) => {
           className="bg-gray-50 m-6 p-4 border-gray-600 border-2
           flex flex-col  max-w-5xl"
         >
-          <div id="metadata-container" className="mx-4 flex flex-row justify-between">
+          <div id="metadata-container" className="mx-4 flex flex-row justify-between items-center">
+            {article.review[0].isAnonymous && <VisibilityOff />}
             <div id="article-metadata" className="m-2">
               <a href={`articles/${article.id}`}>
                 <h2 className="font-bold">{article.title}</h2>
@@ -114,7 +115,11 @@ export const MyReviewsTable = (props) => {
               <div id="review-metadata" className="text-xs">
                 <div id="submitter">
                   Submitted by:{" "}
-                  {currentUser.displayName ? currentUser.displayName : currentUser.handle}
+                  {article.review[0].isAnonymous
+                    ? "Anonymous"
+                    : currentUser.displayName
+                    ? currentUser.displayName
+                    : currentUser.handle}
                 </div>
                 <div id="submitted-on">
                   Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -91,7 +91,6 @@ export const MyReviewsTable = (props) => {
               id="metadata-container"
               className="mx-4 flex flex-row justify-between items-center"
             >
-              {isAnonymous && <VisibilityOff />}
               <div id="article-metadata" className="m-2">
                 <a href={`articles/${article.id}`}>
                   <h2 className="font-bold">{article.title}</h2>
@@ -109,6 +108,8 @@ export const MyReviewsTable = (props) => {
               </div>
               <div className="flex flex-col">
                 <div id="action-menu" className="self-end text-gray-500">
+                  {isAnonymous && <VisibilityOff className="mr-2" />}
+
                   <IconButton onClick={handleClick}>
                     <MoreHoriz />
                   </IconButton>
@@ -136,7 +137,6 @@ export const MyReviewsTable = (props) => {
                       setIsChangeMade={setIsChangeMade}
                     />
                   </Dialog>
-
                   <Box>
                     <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
                       <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -19,6 +19,7 @@ import { MoreHoriz, VisibilityOff } from "@mui/icons-material"
 import deleteReview from "app/mutations/deleteReview"
 import PopupReview from "app/core/components/PopupReview"
 import changeReviewAnonimity from "app/mutations/changeReivewAnonimity"
+import { FaBook, FaUser } from "react-icons/fa"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
@@ -95,10 +96,16 @@ export const MyReviewsTable = (props) => {
                 <a href={`articles/${article.id}`}>
                   <h2 className="font-bold">{article.title}</h2>
                 </a>
-                <div id="author" className="text-sm">
-                  {article.authorString}
+                <div id="author" className="text-sm text-gray-700">
+                  <FaUser className="inline mr-2" />
+                  {article.authorString} ({article.publishedYear})
                 </div>
-                <div className="text-sm text-gray-500">{article.doi}</div>
+                <div className="text-sm text-gray-700">
+                  <FaBook className="inline mr-2" />
+                  <a href={`https://doi.org/${article.doi}`} target="_blank" rel="noreferrer">
+                    {article.doi}
+                  </a>
+                </div>
               </div>
               <div className="flex flex-col">
                 <div id="action-menu" className="self-end text-gray-500">
@@ -116,7 +123,7 @@ export const MyReviewsTable = (props) => {
                   >
                     <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
                     <MenuItem onClick={() => handleChangeAnonymous(article)}>
-                      {isAnonymous ? "Show Your Name" : "Make Anonymous"}
+                      {isAnonymous ? "Make Identifiable" : "Make Anonymous"}
                     </MenuItem>
                     <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
                   </Menu>

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -105,6 +105,7 @@ export const MyReviewsTable = (props) => {
                   <PopupReview
                     article={article}
                     handleClose={closeReviewDialog}
+                    userHasReview={userHasReview}
                     setUserHasReview={setUserHasReview}
                     setIsChangeMade={setIsChangeMade}
                   />

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -1,9 +1,11 @@
-import { Rating } from "@mui/material"
-import React from "react"
+import { IconButton, Menu, MenuItem, Rating } from "@mui/material"
+import React, { useState } from "react"
 import { styled } from "@mui/material/styles"
 import { ReviewStars } from "./ReviewStars"
-import { useQuery } from "blitz"
+import { invoke, useQuery, useRouter } from "blitz"
 import getQuestionCategories from "app/queries/getQuestionCategories"
+import { MoreHoriz } from "@mui/icons-material"
+import deleteReview from "app/mutations/deleteReview"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
@@ -17,6 +19,21 @@ export const MyReviewsTable = (props) => {
       color: "#ff3d47",
     },
   })
+
+  const [anchorEl, setAnchorEl] = useState(null)
+  const actionOpen = Boolean(anchorEl)
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const router = useRouter()
+  const handleDeleteReview = async (currentArticleId) => {
+    await invoke(deleteReview, currentArticleId)
+    router.reload()
+  }
 
   return (
     <>
@@ -36,16 +53,36 @@ export const MyReviewsTable = (props) => {
               </div>
               <div className="text-sm text-gray-500">{article.doi}</div>
             </div>
-            <div id="review-metadata" className="text-xs">
-              <div id="submitter">
-                Submitted by:{" "}
-                {currentUser.displayName ? currentUser.displayName : currentUser.handle}
+            <div className="flex flex-col">
+              <div id="action-menu" className="self-end text-gray-500">
+                <IconButton onClick={handleClick}>
+                  <MoreHoriz />
+                </IconButton>
+                <Menu
+                  id="action-menu"
+                  anchorEl={anchorEl}
+                  open={actionOpen}
+                  onClose={handleClose}
+                  MenuListProps={{
+                    "aria-labelledby": "basic-button",
+                  }}
+                >
+                  <MenuItem onClick={handleClose}>Edit</MenuItem>
+                  <MenuItem onClick={handleClose}>Make Anonymous</MenuItem>
+                  <MenuItem onClick={() => handleDeleteReview(article.id)}>Delete</MenuItem>
+                </Menu>
               </div>
-              <div id="submitted-on">
-                Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}
-              </div>
-              <div id="last-updated-on">
-                Last updated: {article.review[0]?.updatedAt.toISOString().split("T")[0]}
+              <div id="review-metadata" className="text-xs">
+                <div id="submitter">
+                  Submitted by:{" "}
+                  {currentUser.displayName ? currentUser.displayName : currentUser.handle}
+                </div>
+                <div id="submitted-on">
+                  Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}
+                </div>
+                <div id="last-updated-on">
+                  Last updated: {article.review[0]?.updatedAt.toISOString().split("T")[0]}
+                </div>
               </div>
             </div>
           </div>

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -1,4 +1,15 @@
-import { IconButton, Menu, MenuItem, Rating } from "@mui/material"
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+  Rating,
+} from "@mui/material"
 import React, { useState } from "react"
 import { styled } from "@mui/material/styles"
 import { ReviewStars } from "./ReviewStars"
@@ -33,6 +44,13 @@ export const MyReviewsTable = (props) => {
   const handleDeleteReview = async (currentArticleId) => {
     await invoke(deleteReview, currentArticleId)
     router.reload()
+  }
+  const [isDeleteReviewDialogOpen, setIsDeleteReviewDialogOpen] = useState(false)
+  const closeDeleteReviewDialog = () => {
+    setIsDeleteReviewDialogOpen(false)
+  }
+  const openDeleteReviewDialog = () => {
+    setIsDeleteReviewDialogOpen(true)
   }
 
   return (
@@ -69,8 +87,29 @@ export const MyReviewsTable = (props) => {
                 >
                   <MenuItem onClick={handleClose}>Edit</MenuItem>
                   <MenuItem onClick={handleClose}>Make Anonymous</MenuItem>
-                  <MenuItem onClick={() => handleDeleteReview(article.id)}>Delete</MenuItem>
+                  <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
                 </Menu>
+                <Box>
+                  <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
+                    <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>
+                    <DialogContent>
+                      Doing this will delete all of your submitted reviews for this article:{" "}
+                      <div className="font-bold">{article.title}</div>
+                    </DialogContent>
+                    <DialogActions>
+                      <Button onClick={closeDeleteReviewDialog} autoFocus>
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="contained"
+                        color="error"
+                        onClick={() => handleDeleteReview(article.id)}
+                      >
+                        Delete My Reviews
+                      </Button>
+                    </DialogActions>
+                  </Dialog>
+                </Box>
               </div>
               <div id="review-metadata" className="text-xs">
                 <div id="submitter">

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -18,6 +18,7 @@ import getQuestionCategories from "app/queries/getQuestionCategories"
 import { MoreHoriz, VisibilityOff } from "@mui/icons-material"
 import deleteReview from "app/mutations/deleteReview"
 import PopupReview from "app/core/components/PopupReview"
+import changeReviewAnonimity from "app/mutations/changeReivewAnonimity"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
@@ -65,100 +66,119 @@ export const MyReviewsTable = (props) => {
   const [userHasReview, setUserHasReview] = useState(true)
   const [isChangeMade, setIsChangeMade] = useState(false)
 
+  const handleChangeAnonymous = async (article) => {
+    const newAnonymity = !article.review[0].isAnonymous
+    await invoke(changeReviewAnonimity, {
+      userId: currentUser.id,
+      articleId: article.id,
+      isAnonymous: newAnonymity,
+    })
+    router.reload()
+  }
+
   return (
     <>
-      {articleWithReview.map((article) => (
-        <div
-          key={article.id}
-          className="bg-gray-50 m-6 p-4 border-gray-600 border-2
-          flex flex-col  max-w-5xl"
-        >
-          <div id="metadata-container" className="mx-4 flex flex-row justify-between items-center">
-            {article.review[0].isAnonymous && <VisibilityOff />}
-            <div id="article-metadata" className="m-2">
-              <a href={`articles/${article.id}`}>
-                <h2 className="font-bold">{article.title}</h2>
-              </a>
-              <div id="author" className="text-sm">
-                {article.authorString}
-              </div>
-              <div className="text-sm text-gray-500">{article.doi}</div>
-            </div>
-            <div className="flex flex-col">
-              <div id="action-menu" className="self-end text-gray-500">
-                <IconButton onClick={handleClick}>
-                  <MoreHoriz />
-                </IconButton>
-                <Menu
-                  id="action-menu"
-                  anchorEl={anchorEl}
-                  open={actionOpen}
-                  onClose={handleClose}
-                  MenuListProps={{
-                    "aria-labelledby": "basic-button",
-                  }}
-                >
-                  <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
-                  <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
-                </Menu>
-                <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
-                  <PopupReview
-                    article={article}
-                    handleClose={closeReviewDialog}
-                    userHasReview={userHasReview}
-                    setUserHasReview={setUserHasReview}
-                    setIsChangeMade={setIsChangeMade}
-                  />
-                </Dialog>
-
-                <Box>
-                  <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
-                    <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>
-                    <DialogContent>
-                      Doing this will delete all of your submitted reviews for this article:{" "}
-                      <div className="font-bold">{article.title}</div>
-                    </DialogContent>
-                    <DialogActions>
-                      <Button onClick={closeDeleteReviewDialog} autoFocus>
-                        Cancel
-                      </Button>
-                      <Button
-                        variant="contained"
-                        color="error"
-                        onClick={() => handleDeleteReview(article.id)}
-                      >
-                        Delete My Reviews
-                      </Button>
-                    </DialogActions>
-                  </Dialog>
-                </Box>
-              </div>
-              <div id="review-metadata" className="text-xs">
-                <div id="submitter">
-                  Submitted by:{" "}
-                  {article.review[0].isAnonymous
-                    ? "Anonymous"
-                    : currentUser.displayName
-                    ? currentUser.displayName
-                    : currentUser.handle}
-                </div>
-                <div id="submitted-on">
-                  Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}
-                </div>
-                <div id="last-updated-on">
-                  Last updated: {article.review[0]?.updatedAt.toISOString().split("T")[0]}
-                </div>
-              </div>
-            </div>
-          </div>
+      {articleWithReview.map((article) => {
+        const isAnonymous = article.review[0].isAnonymous
+        return (
           <div
-            id="ratings-container"
-            className="flex lg:flex-row flex-col items-center justify-evenly text-xs mx-6"
+            key={article.id}
+            className="bg-gray-50 m-6 p-4 border-gray-600 border-2
+            flex flex-col  max-w-5xl"
           >
-            <ReviewStars reviews={article.review} questionCategories={questionCategories} />
+            <div
+              id="metadata-container"
+              className="mx-4 flex flex-row justify-between items-center"
+            >
+              {isAnonymous && <VisibilityOff />}
+              <div id="article-metadata" className="m-2">
+                <a href={`articles/${article.id}`}>
+                  <h2 className="font-bold">{article.title}</h2>
+                </a>
+                <div id="author" className="text-sm">
+                  {article.authorString}
+                </div>
+                <div className="text-sm text-gray-500">{article.doi}</div>
+              </div>
+              <div className="flex flex-col">
+                <div id="action-menu" className="self-end text-gray-500">
+                  <IconButton onClick={handleClick}>
+                    <MoreHoriz />
+                  </IconButton>
+                  <Menu
+                    id="action-menu"
+                    anchorEl={anchorEl}
+                    open={actionOpen}
+                    onClose={handleClose}
+                    MenuListProps={{
+                      "aria-labelledby": "basic-button",
+                    }}
+                  >
+                    <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
+                    <MenuItem onClick={() => handleChangeAnonymous(article)}>
+                      {isAnonymous ? "Show Your Name" : "Make Anonymous"}
+                    </MenuItem>
+                    <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
+                  </Menu>
+                  <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
+                    <PopupReview
+                      article={article}
+                      handleClose={closeReviewDialog}
+                      userHasReview={userHasReview}
+                      setUserHasReview={setUserHasReview}
+                      setIsChangeMade={setIsChangeMade}
+                    />
+                  </Dialog>
+
+                  <Box>
+                    <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
+                      <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>
+                      <DialogContent>
+                        Doing this will delete all of your submitted reviews for this article:{" "}
+                        <div className="font-bold">{article.title}</div>
+                      </DialogContent>
+                      <DialogActions>
+                        <Button onClick={closeDeleteReviewDialog} autoFocus>
+                          Cancel
+                        </Button>
+                        <Button
+                          variant="contained"
+                          color="error"
+                          onClick={() => handleDeleteReview(article.id)}
+                        >
+                          Delete My Reviews
+                        </Button>
+                      </DialogActions>
+                    </Dialog>
+                  </Box>
+                </div>
+                <div id="review-metadata" className="text-xs">
+                  <div id="submitter">
+                    Submitted by:{" "}
+                    {article.review[0].isAnonymous
+                      ? "Anonymous"
+                      : currentUser.displayName
+                      ? currentUser.displayName
+                      : currentUser.handle}
+                  </div>
+                  <div id="submitted-on">
+                    Submitted: {article.review[0]?.createdAt.toISOString().split("T")[0]}
+                  </div>
+                  <div id="last-updated-on">
+                    Last updated: {article.review[0]?.updatedAt.toISOString().split("T")[0]}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              id="ratings-container"
+              className="flex lg:flex-row flex-col items-center justify-evenly text-xs mx-6"
+            >
+              <ReviewStars reviews={article.review} questionCategories={questionCategories} />
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </>
   )
 }

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -17,6 +17,7 @@ import { invoke, useQuery, useRouter } from "blitz"
 import getQuestionCategories from "app/queries/getQuestionCategories"
 import { MoreHoriz, VisibilityOff } from "@mui/icons-material"
 import deleteReview from "app/mutations/deleteReview"
+import PopupReview from "app/core/components/PopupReview"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
@@ -53,6 +54,17 @@ export const MyReviewsTable = (props) => {
     setIsDeleteReviewDialogOpen(true)
   }
 
+  const handleOpenReviewDialog = () => {
+    handleClose()
+    setIsReviewDialogOpen(true)
+  }
+  const [isReviewDialogOpen, setIsReviewDialogOpen] = useState(false)
+  const closeReviewDialog = () => {
+    setIsReviewDialogOpen(false)
+  }
+  const [userHasReview, setUserHasReview] = useState(true)
+  const [isChangeMade, setIsChangeMade] = useState(false)
+
   return (
     <>
       {articleWithReview.map((article) => (
@@ -86,10 +98,18 @@ export const MyReviewsTable = (props) => {
                     "aria-labelledby": "basic-button",
                   }}
                 >
-                  <MenuItem onClick={handleClose}>Edit</MenuItem>
-                  <MenuItem onClick={handleClose}>Make Anonymous</MenuItem>
+                  <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
                   <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
                 </Menu>
+                <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
+                  <PopupReview
+                    article={article}
+                    handleClose={closeReviewDialog}
+                    setUserHasReview={setUserHasReview}
+                    setIsChangeMade={setIsChangeMade}
+                  />
+                </Dialog>
+
                 <Box>
                   <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
                     <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -24,10 +24,15 @@ export default function PopupReview(prop) {
     reviewAnswerQueryParams
   )
   const [reviewAnswers, setReviewAnswers] = useState(defaultReviewAnswers)
-  const [isAnonymous, setIsAnonymous] = useState(false)
-  const handleChangeAnonymous = () => {
-    if (isAnonymous) setIsAnonymous(false)
-    if (!isAnonymous) setIsAnonymous(true)
+  const [isAnonymous, setIsAnonymous] = useState(
+    reviewAnswers[0]?.isAnonymous ? reviewAnswers[0]?.isAnonymous : false
+  )
+  const handleChangeAnonymous = (event) => {
+    setIsAnonymous(event.target.checked)
+    const newReviewAnswers = reviewAnswers.map((answer) => {
+      return { ...answer, isAnonymous: event.target.checked }
+    })
+    setReviewAnswers(newReviewAnswers)
   }
 
   const updateRating = (questionId, newRating) => {
@@ -40,13 +45,10 @@ export default function PopupReview(prop) {
   const [addReviewMutation] = useMutation(addReview)
   const handleReviewSubmit = async () => {
     setLoading(true)
-    await invoke(addReviewMutation, reviewAnswersToDb)
+    await invoke(addReviewMutation, reviewAnswers)
     setUserHasReview(true)
     window.location.reload()
   }
-  const reviewAnswersToDb = reviewAnswers.map((answer) =>
-    Object.assign(answer, { isAnonymous: isAnonymous })
-  )
   const [loading, setLoading] = useState(false)
   return (
     <>
@@ -85,7 +87,7 @@ export default function PopupReview(prop) {
       <DialogActions>
         <span>
           Submit anonymously
-          <Switch onClick={handleChangeAnonymous} />
+          <Switch checked={isAnonymous} onClick={handleChangeAnonymous} />
           <Tooltip title="If you submit your review anonymously, your handle and display name will be hidden from others.">
             <HelpOutlineIcon />
           </Tooltip>

--- a/app/core/components/PopupReview.tsx
+++ b/app/core/components/PopupReview.tsx
@@ -12,7 +12,7 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
 import { FaBook, FaUser } from "react-icons/fa"
 
 export default function PopupReview(prop) {
-  const { article, handleClose, setUserHasReview, setIsChangeMade } = prop
+  const { article, handleClose, setUserHasReview, setIsChangeMade, userHasReview } = prop
   const [reviewQuestions] = useQuery(getReviewQuestions, undefined)
   const currentUser = useCurrentUser()
   const reviewAnswerQueryParams = {
@@ -36,12 +36,13 @@ export default function PopupReview(prop) {
   }
 
   const updateRating = (questionId, newRating) => {
-    const newAnswers = [...reviewAnswers]
+    const newAnswers = reviewAnswers
     const index = newAnswers.findIndex((r) => r?.questionId === questionId)
     if (index < 0) newAnswers[questionId - 1] = newRating
     if (index >= 0) newAnswers[index] = newRating
     setReviewAnswers(newAnswers)
   }
+
   const [addReviewMutation] = useMutation(addReview)
   const handleReviewSubmit = async () => {
     setLoading(true)
@@ -79,6 +80,7 @@ export default function PopupReview(prop) {
                 onReviewUpdate={updateRating}
                 reviewAnswers={reviewAnswers}
                 setIsChangeMade={setIsChangeMade}
+                isAnonymous={isAnonymous}
               />
             )
           })}
@@ -97,7 +99,7 @@ export default function PopupReview(prop) {
         </Button>
         {/* Need "Are you sure?" Confirmation */}
         <LoadingButton loading={loading} variant="contained" onClick={handleReviewSubmit}>
-          Submit
+          {userHasReview ? "Update" : "Submit"}
         </LoadingButton>
       </DialogActions>
     </>

--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -3,7 +3,7 @@ import Rating from "@mui/material/Rating"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 
 export const ReviewQuestion = (props) => {
-  const { article, question, onReviewUpdate, reviewAnswers, setIsChangeMade } = props
+  const { article, question, onReviewUpdate, reviewAnswers, setIsChangeMade, isAnonymous } = props
   const currentUser = useCurrentUser()
   const handleRatingChange = (questionId, newValue) => {
     const newData = {
@@ -11,6 +11,7 @@ export const ReviewQuestion = (props) => {
       articleId: article.id,
       response: newValue,
       questionId: questionId,
+      isAnonymous: isAnonymous,
     }
     onReviewUpdate(questionId, newData)
   }

--- a/app/mutations/addReview.tsx
+++ b/app/mutations/addReview.tsx
@@ -32,6 +32,7 @@ export default async function addReview(input: z.infer<typeof AddReview>, ctx: C
         },
         update: {
           response: latest.response,
+          isAnonymous: latest.isAnonymous,
         },
         create: {
           ...latest,

--- a/app/mutations/changeReivewAnonimity.tsx
+++ b/app/mutations/changeReivewAnonimity.tsx
@@ -1,0 +1,27 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+import * as z from "zod"
+
+const inputData = z.object({
+  userId: z.number(),
+  articleId: z.string(),
+  isAnonymous: z.boolean(),
+})
+
+export default async function changeReviewAnonimity(input: z.infer<typeof inputData>, ctx: Ctx) {
+  const data = inputData.parse(input)
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  // Update records if existing, if not create records
+  const review = await db.reviewAnswers.updateMany({
+    where: { articleId: data.articleId, userId: data.userId },
+    data: {
+      isAnonymous: data.isAnonymous,
+    },
+  })
+  return review
+}

--- a/app/mutations/deleteReview.tsx
+++ b/app/mutations/deleteReview.tsx
@@ -1,0 +1,21 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+
+export default async function deleteReview(currentArticleId: string, ctx: Ctx) {
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  const currentUserId = ctx.session.userId
+
+  const review = await db.reviewAnswers.deleteMany({
+    where: {
+      articleId: currentArticleId,
+      userId: currentUserId,
+    },
+  })
+
+  return review
+}

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -79,7 +79,7 @@ const Profile = () => {
                 onChange={handleHandleChange}
               />
               <IconButton onClick={changeHandle}>
-                <EditIcon></EditIcon>
+                <EditIcon />
               </IconButton>
             </div>
             <div id="user-name-container" className="m-2">
@@ -92,7 +92,7 @@ const Profile = () => {
                 size="small"
               />
               <IconButton>
-                <EditIcon></EditIcon>
+                <EditIcon />
               </IconButton>
             </div>
             <div id="user-email-container" className="m-2">
@@ -105,7 +105,7 @@ const Profile = () => {
                 size="small"
               />
               <IconButton>
-                <EditIcon></EditIcon>
+                <EditIcon />
               </IconButton>
             </div>
           </div>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -117,17 +117,18 @@ const Profile = () => {
             <MyReviewsTable articleWithReview={myArticlesWithReview} currentUser={currentUser} />
           </div>
         </div>
-        <div>
-          <div id="public-view-container" className="m-2 text-blue-500 font-semibold">
+        <div className="m-6">
+          <Button id="public-view-container" className="m-2 text-blue-500 font-semibold">
             <a href="#">Public profile view</a>
-          </div>
-          <div
+          </Button>
+          <Button
             id="delete-account"
             className="m-2 font-semibold hover:cursor-pointer text-red-400"
             onClick={openDeactivateAccountDialog}
+            color="error"
           >
             Deactivate your account
-          </div>
+          </Button>
           <Box>
             <Dialog open={isDeactivateAccountDialogOpen} onClose={closeDeactivateAccountDialog}>
               <DialogTitle id="deactivate-account">{"Deactivating Your Account"}</DialogTitle>


### PR DESCRIPTION
This PR updates the action menu on the profile page, so that people can edit, change anonymity, or delete their reviews.

When the review is non-anonymous:
![image](https://user-images.githubusercontent.com/17035406/155013498-c8aa1871-0f00-4803-8888-e6cfd89e10e7.png)

When the review is already anonymous:
![image](https://user-images.githubusercontent.com/17035406/155013532-8afccbef-4787-43ee-9fda-58b1b383a634.png)

@coglebed : I'm not sure "Show Your Name" is the best phrase there. Let me know if you can think of a better language 👋 


Fixes #103 

- Implement delete review on profile
- Add a confirmation dialog for deleting reviews
- Use MUI Button on the profile
- Show anonymity status on the review card
- Fix review mutation to handle anonymity
- Make the anonymous button controlled
- Implement a review popup on the profile page
- Add anonymous boolean to handle rating change
- Pass `userHasReview` to PopupReview
- Show "Update" when updating a review
- Cleanup code
- Add a db mutation to change anonymity
- Implement the db mutation to change anonimity
