### PR TITLE
Add a link to the code of conduct to the footer

### DIFF
--- a/app/core/components/Footer.tsx
+++ b/app/core/components/Footer.tsx
@@ -11,7 +11,16 @@ export const Footer = () => {
         <div className="m-3 mx-6 flex-grow">PostReview {datetime.getFullYear()}</div>
         <ul className="mx-6">
           <li className="inline mx-4">Terms</li>
-          <li className="inline mx-4">About us</li>
+          <li className="inline mx-4">
+            <a
+              href="https://github.com/nsunami/postreview-app/blob/main/CODE_OF_CONDUCT.md"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Code of Conduct
+            </a>
+          </li>
+          <li className="inline mx-4">About Us</li>
         </ul>
         <ul className="mx-6">
           <li className="inline mx-4">


### PR DESCRIPTION
This PR adds a link to the code of conduct to the footer. 
Fixes #112 

![image](https://user-images.githubusercontent.com/17035406/155014879-6828c897-2b7f-40c6-b4a1-1b3a489d2091.png)
