### PR TITLE
On the landing page, remove the search bar, limit papers to 2, and move the sign-up button to the bottom

### DIFF
--- a/app/core/components/ArticleList.tsx
+++ b/app/core/components/ArticleList.tsx
@@ -2,20 +2,24 @@ import getArticles from "app/queries/getArticles"
 import React, { Suspense } from "react"
 import { useQuery } from "blitz"
 import Article from "./Article"
+import { useCurrentUser } from "../hooks/useCurrentUser"
 
 export default function ArticleList() {
   const [defaultArticles] = useQuery(getArticles, undefined)
+  const currentUser = useCurrentUser()
+  const showMax = currentUser ? 100 : 1
 
   if (!defaultArticles) return null
   return (
     <div className="mt-10">
       <h1 className="text-xl">Trending Papers</h1>
-      {defaultArticles?.map((article) => {
-        return (
-          <Suspense fallback="loading" key={article.id}>
-            <Article key={article.id} {...article} />
-          </Suspense>
-        )
+      {defaultArticles?.map((article, index) => {
+        if (index <= showMax)
+          return (
+            <Suspense fallback="loading" key={article.id}>
+              <Article key={article.id} {...article} />
+            </Suspense>
+          )
       })}
     </div>
   )

--- a/app/core/components/Header.tsx
+++ b/app/core/components/Header.tsx
@@ -1,8 +1,10 @@
 import React from "react"
 import { HeaderUserButton } from "./HeaderUserButton"
 import EnterDOI from "./EnterDOI"
+import { useCurrentUser } from "../hooks/useCurrentUser"
 
 export default function Header() {
+  const currentUser = useCurrentUser()
   return (
     <>
       <header className="bg-gray-100 flex flex-row items-center h-16">
@@ -10,7 +12,7 @@ export default function Header() {
           <a href="/">PostReview</a>
         </div>
         <div id="search-bar-container" className="flex flex-grow justify-end">
-          <EnterDOI />
+          {currentUser && <EnterDOI />}
         </div>
         <div id="buttons-container" className="mr-4 flex flex-row">
           <HeaderUserButton />

--- a/app/core/components/Hero.tsx
+++ b/app/core/components/Hero.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { HeaderUserButton } from "./HeaderUserButton"
 
 export const Hero = () => {
   return (
@@ -8,14 +9,7 @@ export const Hero = () => {
         Share your thoughts with those who care—Opinions in science have never been this accessible
       </div>
       <div id="action-container" className="mb-6 mt-12">
-        <input
-          type="text"
-          className="rounded-full placeholder-gray-500 px-12 bg-gray-100 h-8"
-          placeholder="Article title / DOI"
-        />
-        <button className="bg-blue-400 mx-2 rounded-full h-8 w-auto px-4 text-white">
-          Start Browsing
-        </button>
+        <HeaderUserButton />
       </div>
     </div>
   )

--- a/app/core/components/SignUpButton.tsx
+++ b/app/core/components/SignUpButton.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@mui/material"
 import React from "react"
+import { HeaderUserButton } from "./HeaderUserButton"
 
 export const SignUpButton = () => {
   return (
-    <div className="my-14">
-      <Button variant="contained">Sign Up Today</Button>
+    <div className="my-24">
+      <HeaderUserButton />
     </div>
   )
 }

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -40,9 +40,9 @@ const UserInfo = () => {
         <Hero />
         <Features />
         <HowItWorks />
-        <SignUpButton />
         <Visions />
         <ArticleList />
+        <SignUpButton />
       </>
     )
   }


### PR DESCRIPTION
This PR:
- Replaces the search bar in the hero section with a logging button
- Hides the search bar at the top when not logged in (fix #109)
- Limits trending papers to 2 when not logged in (fix #111)
- Moves the sign up button to the bottom (fix #111)