### PR TITLE
Fix the profile page actions

### DIFF
--- a/app/core/components/ArticleAction.tsx
+++ b/app/core/components/ArticleAction.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react"
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Menu,
+  MenuItem,
+} from "@mui/material"
+import { invoke, useRouter } from "blitz"
+import deleteReview from "app/mutations/deleteReview"
+import PopupReview from "app/core/components/PopupReview"
+import changeReviewAnonimity from "app/mutations/changeReivewAnonimity"
+import { MoreHoriz } from "@mui/icons-material"
+import { useCurrentUser } from "../hooks/useCurrentUser"
+
+export const ArticleAction = (props) => {
+  const { article, setMyArticlesWithReview } = props
+  const currentUser = useCurrentUser()
+  const router = useRouter()
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const actionOpen = Boolean(anchorEl)
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleDeleteReview = async (currentArticleId) => {
+    await invoke(deleteReview, currentArticleId)
+    router.reload()
+  }
+  const [isDeleteReviewDialogOpen, setIsDeleteReviewDialogOpen] = useState(false)
+  const closeDeleteReviewDialog = () => {
+    setIsDeleteReviewDialogOpen(false)
+  }
+  const openDeleteReviewDialog = () => {
+    setIsDeleteReviewDialogOpen(true)
+  }
+
+  const handleOpenReviewDialog = () => {
+    handleClose()
+    setIsReviewDialogOpen(true)
+  }
+  const [isReviewDialogOpen, setIsReviewDialogOpen] = useState(false)
+  const closeReviewDialog = () => {
+    setIsReviewDialogOpen(false)
+  }
+  const [userHasReview, setUserHasReview] = useState(true)
+  const [isChangeMade, setIsChangeMade] = useState(false)
+
+  const handleChangeAnonymous = async (article) => {
+    const newAnonymity = !article.review[0].isAnonymous
+    await invoke(changeReviewAnonimity, {
+      userId: currentUser?.id,
+      articleId: article.id,
+      isAnonymous: newAnonymity,
+    })
+    router.reload()
+  }
+  const isAnonymous = article.review[0].isAnonymous
+
+  return (
+    <>
+      <IconButton onClick={handleClick}>
+        <MoreHoriz />
+      </IconButton>
+      <Menu
+        id="action-menu"
+        anchorEl={anchorEl}
+        open={actionOpen}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
+        <MenuItem onClick={() => handleChangeAnonymous(article)}>
+          {isAnonymous ? "Make Identifiable" : "Make Anonymous"}
+        </MenuItem>
+        <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
+      </Menu>
+      <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
+        <PopupReview
+          article={article}
+          handleClose={closeReviewDialog}
+          userHasReview={userHasReview}
+          setUserHasReview={setUserHasReview}
+          setIsChangeMade={setIsChangeMade}
+        />
+      </Dialog>
+      <Box>
+        <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
+          <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>
+          <DialogContent>
+            Doing this will delete all of your submitted reviews for this article:{" "}
+            <div className="font-bold">{article.title}</div>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={closeDeleteReviewDialog} autoFocus>
+              Cancel
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => handleDeleteReview(article.id)}
+            >
+              Delete My Reviews
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Box>
+    </>
+  )
+}

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -1,81 +1,14 @@
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Menu,
-  MenuItem,
-  Rating,
-} from "@mui/material"
-import React, { useState } from "react"
-import { styled } from "@mui/material/styles"
-import { invoke, useQuery, useRouter } from "blitz"
+import React from "react"
+import { useQuery } from "blitz"
 import getQuestionCategories from "app/queries/getQuestionCategories"
-import { MoreHoriz, VisibilityOff } from "@mui/icons-material"
-import deleteReview from "app/mutations/deleteReview"
-import PopupReview from "app/core/components/PopupReview"
-import changeReviewAnonimity from "app/mutations/changeReivewAnonimity"
+import { VisibilityOff } from "@mui/icons-material"
 import { FaBook, FaUser } from "react-icons/fa"
 import { Review } from "app/core/components/Review"
+import { ArticleAction } from "./ArticleAction"
 
 export const MyReviewsTable = (props) => {
   const { articleWithReview, currentUser } = props
   const [questionCategories] = useQuery(getQuestionCategories, undefined)
-
-  const RatingTotal = styled(Rating)({
-    "& .MuiRating-iconFilled": {
-      color: "#f28c6d",
-    },
-    "& .MuiRating-iconHover": {
-      color: "#ff3d47",
-    },
-  })
-
-  const [anchorEl, setAnchorEl] = useState(null)
-  const actionOpen = Boolean(anchorEl)
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget)
-  }
-  const handleClose = () => {
-    setAnchorEl(null)
-  }
-
-  const router = useRouter()
-  const handleDeleteReview = async (currentArticleId) => {
-    await invoke(deleteReview, currentArticleId)
-    router.reload()
-  }
-  const [isDeleteReviewDialogOpen, setIsDeleteReviewDialogOpen] = useState(false)
-  const closeDeleteReviewDialog = () => {
-    setIsDeleteReviewDialogOpen(false)
-  }
-  const openDeleteReviewDialog = () => {
-    setIsDeleteReviewDialogOpen(true)
-  }
-
-  const handleOpenReviewDialog = () => {
-    handleClose()
-    setIsReviewDialogOpen(true)
-  }
-  const [isReviewDialogOpen, setIsReviewDialogOpen] = useState(false)
-  const closeReviewDialog = () => {
-    setIsReviewDialogOpen(false)
-  }
-  const [userHasReview, setUserHasReview] = useState(true)
-  const [isChangeMade, setIsChangeMade] = useState(false)
-
-  const handleChangeAnonymous = async (article) => {
-    const newAnonymity = !article.review[0].isAnonymous
-    await invoke(changeReviewAnonimity, {
-      userId: currentUser.id,
-      articleId: article.id,
-      isAnonymous: newAnonymity,
-    })
-    router.reload()
-  }
 
   return (
     <>
@@ -117,54 +50,7 @@ export const MyReviewsTable = (props) => {
               <div className="flex flex-col">
                 <div id="action-menu" className="self-end text-gray-500">
                   {isAnonymous && <VisibilityOff className="mr-2" />}
-                  <IconButton onClick={handleClick}>
-                    <MoreHoriz />
-                  </IconButton>
-                  <Menu
-                    id="action-menu"
-                    anchorEl={anchorEl}
-                    open={actionOpen}
-                    onClose={handleClose}
-                    MenuListProps={{
-                      "aria-labelledby": "basic-button",
-                    }}
-                  >
-                    <MenuItem onClick={handleOpenReviewDialog}>Edit</MenuItem>
-                    <MenuItem onClick={() => handleChangeAnonymous(article)}>
-                      {isAnonymous ? "Make Identifiable" : "Make Anonymous"}
-                    </MenuItem>
-                    <MenuItem onClick={openDeleteReviewDialog}>Delete</MenuItem>
-                  </Menu>
-                  <Dialog open={isReviewDialogOpen} onClose={closeReviewDialog}>
-                    <PopupReview
-                      article={article}
-                      handleClose={closeReviewDialog}
-                      userHasReview={userHasReview}
-                      setUserHasReview={setUserHasReview}
-                      setIsChangeMade={setIsChangeMade}
-                    />
-                  </Dialog>
-                  <Box>
-                    <Dialog open={isDeleteReviewDialogOpen} onClose={closeDeleteReviewDialog}>
-                      <DialogTitle id="deactivate-account">{"Deleting Your Review"}</DialogTitle>
-                      <DialogContent>
-                        Doing this will delete all of your submitted reviews for this article:{" "}
-                        <div className="font-bold">{article.title}</div>
-                      </DialogContent>
-                      <DialogActions>
-                        <Button onClick={closeDeleteReviewDialog} autoFocus>
-                          Cancel
-                        </Button>
-                        <Button
-                          variant="contained"
-                          color="error"
-                          onClick={() => handleDeleteReview(article.id)}
-                        >
-                          Delete My Reviews
-                        </Button>
-                      </DialogActions>
-                    </Dialog>
-                  </Box>
+                  <ArticleAction curentUser={currentUser} article={article} />
                 </div>
               </div>
             </div>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -23,9 +23,11 @@ import logout from "app/auth/mutations/logout"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
-  const [myArticlesWithReview] = useQuery(getReviewAnswersByUserId, {
+  const [defaultMyArticlesWithReview] = useQuery(getReviewAnswersByUserId, {
     currentUserId: currentUser?.id,
   })
+
+  const [myArticlesWithReview, setMyArticlesWithReview] = useState(defaultMyArticlesWithReview)
   const [handleDisabled, setHandleDisabled] = useState(true)
   const [isDeactivateAccountDialogOpen, setIsDeactivateAccountDialogOpen] = useState(false)
   const changeHandle = () => {


### PR DESCRIPTION
This PR fixes the problem where we can only perform actions (edit, make anonymous, delete) on the last article on the profile page (fixes #125).


The underlying problem was that the action menus etc were being rendered for all the articles at the same time. The solution is to separate a component for rendering a button and corresponding dialog boxes.

- Use the state hook to control articles with review
- Separate the article action menu


Side note: While working on this issue, I realized places where we can use the react state hook instead of reloading a page. Opened an issue for a future enhancement (#126).
