### PR TITLE
Avoid 400 by controlling the star and handling empty question answers 

### DIFF
--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import Rating from "@mui/material/Rating"
 import { useCurrentUser } from "../hooks/useCurrentUser"
 
@@ -15,7 +15,10 @@ export const ReviewQuestion = (props) => {
     }
     onReviewUpdate(questionId, newData)
   }
-  const currentAnswer = reviewAnswers.find((answer) => answer.questionId == question.questionId)
+  const defaultCurrentAnswer = reviewAnswers.find(
+    (answer) => answer.questionId == question.questionId
+  )
+  const [currentAnswer, setCurrentAnswer] = useState(defaultCurrentAnswer)
 
   return (
     <div
@@ -48,6 +51,7 @@ export const ReviewQuestion = (props) => {
             name="customized-10"
             max={question.maxValue}
             onChange={(event, newValue) => {
+              setCurrentAnswer({ ...currentAnswer, response: newValue })
               handleRatingChange(question.questionId, newValue)
               setIsChangeMade(true)
             }}

--- a/app/core/components/ReviewQuestion.tsx
+++ b/app/core/components/ReviewQuestion.tsx
@@ -16,7 +16,7 @@ export const ReviewQuestion = (props) => {
     onReviewUpdate(questionId, newData)
   }
   const defaultCurrentAnswer = reviewAnswers.find(
-    (answer) => answer.questionId == question.questionId
+    (answer) => answer?.questionId == question.questionId
   )
   const [currentAnswer, setCurrentAnswer] = useState(defaultCurrentAnswer)
 

--- a/app/pages/articles/[articleId].tsx
+++ b/app/pages/articles/[articleId].tsx
@@ -32,7 +32,6 @@ const ArticleDetails = () => {
   const handleConfirmDiscard = () => {
     setIsConfirmDialogOpen(false)
     setIsReviewDialogOpen(false)
-    if (!articleHasReview) router.push("/")
   }
   const currentUser = useCurrentUser()
   const [defaultUserHasReview] = useQuery(hasUserSunmittedReview, {


### PR DESCRIPTION
This PR avoids 400 (fix #85) via making the star rating controlled component and handling empty question answers.
