### PR TITLE
Add functionality to change the handle and display name on the profile page

### DIFF
--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -43,6 +43,7 @@ export const MyReviewsTable = (props) => {
             <div className="flex flex-row justify-center items-center">
               <Review
                 displayName={currentUser.displayName}
+                handle={currentUser.handle}
                 reviews={article.review}
                 userIcon={currentUser.icon}
                 questionCategories={questionCategories}

--- a/app/core/components/Review.tsx
+++ b/app/core/components/Review.tsx
@@ -3,11 +3,11 @@ import React from "react"
 import { ReviewStars } from "./ReviewStars"
 
 export const Review = (props) => {
-  const { displayName, reviews, userIcon, questionCategories } = props
+  const { displayName, handle, reviews, userIcon, questionCategories } = props
   const submittedAt = reviews[0]?.createdAt?.toISOString().split("T")[0]
   const updatedAt = reviews[0]?.updatedAt.toISOString().split("T")[0]
   const isAnonymous = reviews[0]?.isAnonymous
-  const submittedBy = isAnonymous ? "Anonymous" : displayName
+  const submittedBy = isAnonymous ? "Anonymous" : displayName ? displayName : `@${handle}`
   const submittedByIcon = userIcon
   const tooltipText = `Submitted by: ${submittedBy} | Submitted: ${submittedAt} | Last updated: ${updatedAt} `
 

--- a/app/core/components/ReviewList.tsx
+++ b/app/core/components/ReviewList.tsx
@@ -30,7 +30,7 @@ export const ReviewList = (prop) => {
             {currentUserHasReview ? (
               <Review
                 key={currentUserReview?.id}
-                displayName={currentUserReview?.handle}
+                displayName={currentUserReview?.displayName}
                 handle={currentUserReview?.handle}
                 reviews={currentUserReview?.review}
                 userIcon={currentUserReview?.icon}
@@ -49,7 +49,7 @@ export const ReviewList = (prop) => {
             otherUserReview.map((user) => (
               <Review
                 key={user.id}
-                displayName={user.handle}
+                displayName={user.displayName}
                 handle={user.handle}
                 reviews={user.review}
                 questionCategories={questionCategories}

--- a/app/mutations/changeDisplayName.tsx
+++ b/app/mutations/changeDisplayName.tsx
@@ -1,0 +1,25 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+import * as z from "zod"
+
+const inputData = z.object({
+  id: z.number(),
+  displayName: z.string(),
+})
+
+export default async function changeDisplayName(input: z.infer<typeof inputData>, ctx: Ctx) {
+  const data = inputData.parse(input)
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  const result = await db.user.update({
+    where: { id: data.id },
+    data: {
+      displayName: data.displayName,
+    },
+  })
+  return result
+}

--- a/app/mutations/changeEmail.tsx
+++ b/app/mutations/changeEmail.tsx
@@ -1,0 +1,25 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+import * as z from "zod"
+
+const inputData = z.object({
+  id: z.number(),
+  email: z.string(),
+})
+
+export default async function changeEmail(input: z.infer<typeof inputData>, ctx: Ctx) {
+  const data = inputData.parse(input)
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  const result = await db.user.update({
+    where: { id: data.id },
+    data: {
+      email: data.email,
+    },
+  })
+  return result
+}

--- a/app/mutations/changeUserHandle.tsx
+++ b/app/mutations/changeUserHandle.tsx
@@ -1,0 +1,25 @@
+import db from "db"
+import { Ctx, AuthorizationError } from "blitz"
+import * as z from "zod"
+
+const inputData = z.object({
+  id: z.number(),
+  handle: z.string(),
+})
+
+export default async function changeUserHandle(input: z.infer<typeof inputData>, ctx: Ctx) {
+  const data = inputData.parse(input)
+  ctx.session.$authorize()
+
+  if (!ctx.session.userId) {
+    throw new AuthorizationError()
+  }
+
+  const result = await db.user.update({
+    where: { id: data.id },
+    data: {
+      handle: data.handle,
+    },
+  })
+  return result
+}

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -20,23 +20,28 @@ import { MyReviewsEmptyState } from "app/core/components/MyReviewsEmptyState"
 import { Footer } from "app/core/components/Footer"
 import deleteUser from "app/mutations/deleteUser"
 import logout from "app/auth/mutations/logout"
+import changeUserHandle from "app/mutations/changeUserHandle"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
   const [defaultMyArticlesWithReview] = useQuery(getReviewAnswersByUserId, {
     currentUserId: currentUser?.id,
   })
+  const [myHandle, setMyHandle] = useState(currentUser?.handle)
 
   const [myArticlesWithReview, setMyArticlesWithReview] = useState(defaultMyArticlesWithReview)
   const [handleDisabled, setHandleDisabled] = useState(true)
   const [isDeactivateAccountDialogOpen, setIsDeactivateAccountDialogOpen] = useState(false)
   const changeHandle = () => {
-    if (!handleDisabled) setHandleDisabled(true)
+    if (!handleDisabled) {
+      invoke(changeUserHandle, { id: currentUser?.id, handle: myHandle })
+      setHandleDisabled(true)
+    }
     if (handleDisabled) setHandleDisabled(false)
   }
 
   const handleHandleChange = (event) => {
-    console.log(event.target.value)
+    setMyHandle(event.target.value)
   }
 
   const openDeactivateAccountDialog = () => {
@@ -75,7 +80,7 @@ const Profile = () => {
                 id="outlined-basic"
                 label="Handle"
                 variant="filled"
-                defaultValue={currentUser?.handle}
+                defaultValue={myHandle}
                 size="small"
                 onChange={handleHandleChange}
               />

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -8,6 +8,7 @@ import {
   DialogContent,
   DialogTitle,
   IconButton,
+  InputAdornment,
   TextField,
 } from "@mui/material"
 import { Box } from "@mui/system"
@@ -95,6 +96,9 @@ const Profile = () => {
                 defaultValue={myHandle}
                 size="small"
                 onChange={handleHandleChange}
+                InputProps={{
+                  startAdornment: <InputAdornment position="start">@</InputAdornment>,
+                }}
               />
               <IconButton onClick={changeHandle}>
                 <EditIcon />
@@ -123,9 +127,10 @@ const Profile = () => {
                 defaultValue={currentUser?.email}
                 size="small"
               />
-              <IconButton>
+              {/* Commenting out the email change function for now */}
+              {/* <IconButton>
                 <EditIcon />
-              </IconButton>
+              </IconButton> */}
             </div>
           </div>
         </div>

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -21,6 +21,7 @@ import { Footer } from "app/core/components/Footer"
 import deleteUser from "app/mutations/deleteUser"
 import logout from "app/auth/mutations/logout"
 import changeUserHandle from "app/mutations/changeUserHandle"
+import changeDisplayName from "app/mutations/changeDisplayName"
 
 const Profile = () => {
   const currentUser = useCurrentUser()
@@ -28,9 +29,12 @@ const Profile = () => {
     currentUserId: currentUser?.id,
   })
   const [myHandle, setMyHandle] = useState(currentUser?.handle)
+  const [myDisplayName, setMyDisplayName] = useState(currentUser?.displayName)
 
   const [myArticlesWithReview, setMyArticlesWithReview] = useState(defaultMyArticlesWithReview)
   const [handleDisabled, setHandleDisabled] = useState(true)
+  const [myDisplayNameDisabled, setMyDisplayNameDisabled] = useState(true)
+
   const [isDeactivateAccountDialogOpen, setIsDeactivateAccountDialogOpen] = useState(false)
   const changeHandle = () => {
     if (!handleDisabled) {
@@ -38,6 +42,14 @@ const Profile = () => {
       setHandleDisabled(true)
     }
     if (handleDisabled) setHandleDisabled(false)
+  }
+
+  const handleChangeDisplayName = () => {
+    if (!myDisplayNameDisabled) {
+      invoke(changeDisplayName, { id: currentUser?.id, displayName: myDisplayName })
+      setMyDisplayNameDisabled(true)
+    }
+    if (myDisplayNameDisabled) setMyDisplayNameDisabled(false)
   }
 
   const handleHandleChange = (event) => {
@@ -90,14 +102,15 @@ const Profile = () => {
             </div>
             <div id="user-name-container" className="m-2">
               <TextField
-                disabled
+                disabled={myDisplayNameDisabled}
                 id="user-name"
                 label="Display Name (optional)"
                 variant="filled"
-                defaultValue={currentUser?.displayName}
+                defaultValue={myDisplayName}
                 size="small"
+                onChange={(event) => setMyDisplayName(event.target.value)}
               />
-              <IconButton>
+              <IconButton onClick={handleChangeDisplayName}>
                 <EditIcon />
               </IconButton>
             </div>


### PR DESCRIPTION
This PR adds functionality to change a user handle and a user's display name on the profile page (fix #74). I did not add functionality to change the user's email since it is currently tied to Google OAuth. Need to pick it up when we have an in-house sign-on function.

This PR also includes a small fix to show handles with `@` prefix. And a bugfix where the display name was passed as a handle on the article page.
