### PR TITLE
Show the number of users with ratings in the chip for the article card

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -7,6 +7,7 @@ import StarIcon from "@mui/icons-material/Star"
 import { useQuery } from "blitz"
 import getArticleScoresById from "app/queries/getArticleScoresById"
 import getQuestionCategories from "app/queries/getQuestionCategories"
+import getUssersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByArticleId"
 
 export default function Article(props) {
   const { id, authorString, doi, title } = props
@@ -17,7 +18,11 @@ export default function Article(props) {
 
   const [questionCategories] = useQuery(getQuestionCategories, undefined)
 
-  const ratingsCount = articleScores.length
+  const [usersWithReview] = useQuery(getUssersWithReviewsByArticleId, {
+    currentArticleId: id,
+  })
+  const ratingsCount = usersWithReview.length
+
   const totalRating = articleScores.reduce((prev, current) => {
     // console.log("prev: " + prev)
     // console.log("current: " + current._avg.response)

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -13,7 +13,7 @@ export default function Article(props) {
   const { id, authorString, doi, title } = props
 
   const [articleScores] = useQuery(getArticleScoresById, {
-    articleId: id,
+    currentArticleId: id,
   })
 
   const [questionCategories] = useQuery(getQuestionCategories, undefined)

--- a/app/queries/getArticleScoresById.tsx
+++ b/app/queries/getArticleScoresById.tsx
@@ -1,10 +1,10 @@
 import db from "db"
 
 export default async function getArticleScoresById(props) {
-  const { articleId } = props
+  const { currentArticleId } = props
   return await db.reviewAnswers.groupBy({
     by: ["articleId", "questionId"],
-    where: { articleId: articleId },
+    where: { articleId: currentArticleId },
     _avg: {
       response: true,
     },


### PR DESCRIPTION
This PR fixes the chip for the article card so that it shows the number of users with a review.

This PR also includes a small change in naming a prop for the `getArticleScoresById` query, so that the queries have a consistent name for the input article ID (`currentArticleId`).