### PR TITLE
Show rating values on top of the stars on the article card

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -12,6 +12,8 @@ import getUssersWithReviewsByArticleId from "app/queries/getUsersWithReviewsByAr
 export default function Article(props) {
   const { id, authorString, doi, title } = props
 
+  const ratingScaleMax = 5
+
   const [articleScores] = useQuery(getArticleScoresById, {
     currentArticleId: id,
   })
@@ -78,17 +80,22 @@ export default function Article(props) {
                 />
               </div>
             ) : (
-              <Rating
-                readOnly
-                value={totalRating / 5}
-                precision={0.1}
-                max={1}
-                sx={{
-                  fontSize: 100,
-                  color: "#FF5733",
-                }}
-                emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
-              />
+              <div className="flex items-center justify-center">
+                <div className="absolute text-white font-semibold text-base z-50">
+                  {totalRating.toFixed(1)}
+                </div>
+                <Rating
+                  readOnly
+                  value={totalRating / ratingScaleMax}
+                  precision={0.1}
+                  max={1}
+                  sx={{
+                    fontSize: 100,
+                    color: "#FF5733",
+                  }}
+                  emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+                />
+              </div>
             )}
           </div>
           Total
@@ -97,20 +104,27 @@ export default function Article(props) {
           articleScores.find((score) => score.questionId === category.questionId)?._avg
             .response! ? (
             <div key={category.questionId} className="text-center">
-              <Rating
-                readOnly
-                value={
-                  articleScores.find((score) => score.questionId === category.questionId)?._avg
-                    .response! / 5
-                }
-                precision={0.1}
-                max={1}
-                sx={{
-                  fontSize: 100,
-                  color: "#FFC300",
-                }}
-                emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
-              />
+              <div className="flex items-center justify-center">
+                <div className="absolute text-white font-semibold text-base z-50">
+                  {articleScores
+                    .find((score) => score.questionId === category.questionId)
+                    ?._avg.response!.toFixed(1)}
+                </div>
+                <Rating
+                  readOnly
+                  value={
+                    articleScores.find((score) => score.questionId === category.questionId)?._avg
+                      .response! / ratingScaleMax
+                  }
+                  precision={0.1}
+                  max={1}
+                  sx={{
+                    fontSize: 100,
+                    color: "#FFC300",
+                  }}
+                  emptyIcon={<StarIcon style={{ opacity: 0.55 }} fontSize="inherit" />}
+                />
+              </div>
               <div>{category.questionCategory}</div>
             </div>
           ) : (


### PR DESCRIPTION
This PR shows the aggregated rating scores on top of the starts on the article card. Previously, the stars did not have numbers on them (fixes #135).  

![image](https://user-images.githubusercontent.com/17035406/157240923-de0a081a-df0c-4edb-8d97-4decbc09bfd4.png)
