### PR TITLE
Use the Link component throughout the app

### DIFF
--- a/app/core/components/Header.tsx
+++ b/app/core/components/Header.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { HeaderUserButton } from "./HeaderUserButton"
 import EnterDOI from "./EnterDOI"
 import { useCurrentUser } from "../hooks/useCurrentUser"
+import { Link } from "blitz"
 
 export default function Header() {
   const currentUser = useCurrentUser()
@@ -9,7 +10,7 @@ export default function Header() {
     <>
       <header className="bg-gray-100 flex flex-row items-center h-16">
         <div className="mx-6 text-2xl">
-          <a href="/">PostReview</a>
+          <Link href="/">PostReview</Link>
         </div>
         <div id="search-bar-container" className="flex flex-grow justify-center">
           {currentUser && <EnterDOI />}

--- a/app/core/components/MyReviewsTable.tsx
+++ b/app/core/components/MyReviewsTable.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useQuery } from "blitz"
+import { Link, useQuery } from "blitz"
 import getQuestionCategories from "app/queries/getQuestionCategories"
 import { FaBook, FaUser } from "react-icons/fa"
 import { Review } from "app/core/components/Review"
@@ -23,9 +23,11 @@ export const MyReviewsTable = (props) => {
               className="mx-4 flex flex-row justify-between items-center"
             >
               <div id="article-metadata" className="m-2">
-                <a href={`/articles/${article.id}`}>
-                  <h2 className="font-bold">{article.title}</h2>
-                </a>
+                <Link href={`/articles/${article.id}`}>
+                  <a>
+                    <h2 className="font-bold">{article.title}</h2>
+                  </a>
+                </Link>
                 <div id="author" className="text-sm text-gray-700">
                   <FaUser className="inline mr-2" />
                   {article.authorString} ({article.publishedYear})

--- a/app/pages/profile.tsx
+++ b/app/pages/profile.tsx
@@ -1,4 +1,4 @@
-import { BlitzPage, invoke, useMutation, useQuery, useRouter } from "blitz"
+import { BlitzPage, invoke, Link, useMutation, useQuery, useRouter } from "blitz"
 import EditIcon from "@mui/icons-material/Edit"
 import {
   Avatar,
@@ -135,7 +135,7 @@ const Profile = () => {
         </div>
         <div className="m-6">
           <Button id="public-view-container" className="m-2 text-blue-500 font-semibold">
-            <a href={publicProfileLink}>Public profile view</a>
+            <Link href={publicProfileLink}>Public profile view</Link>
           </Button>
           <Button
             id="delete-account"


### PR DESCRIPTION
This PR replaces the `<a>` tag with `<Link>` whenever possible. Fixes #167.