### PR TITLE
Add the How It Works page

### DIFF
--- a/app/core/components/Footer.tsx
+++ b/app/core/components/Footer.tsx
@@ -12,6 +12,9 @@ export const Footer = () => {
       <div className="h-16 flex flex-row items-center sm:w-full lg:w-5/6 mx-auto">
         <div className="m-3 mx-6 flex-grow">PostReview {datetime.getFullYear()}</div>
         <ul className="mx-6">
+          <li className="inline mx-4">
+            <Link href="/how-it-works">How It Works</Link>
+          </li>
           <li className="inline mx-4">Terms</li>
           <li className="inline mx-4">
             <a

--- a/app/pages/how-it-works.tsx
+++ b/app/pages/how-it-works.tsx
@@ -1,0 +1,21 @@
+import { Footer } from "app/core/components/Footer"
+import Header from "app/core/components/Header"
+import { HowItWorks } from "app/core/components/HowItWorks"
+import { BlitzPage } from "blitz"
+import { Suspense } from "react"
+
+const HowItWorksPage: BlitzPage = () => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Suspense fallback="Loading...">
+        <Header />
+      </Suspense>
+      <main className="flex-grow flex flex-col items-center mb-12">
+        <HowItWorks />
+      </main>
+      <Footer />
+    </div>
+  )
+}
+
+export default HowItWorksPage


### PR DESCRIPTION
This PR adds a page showing how the app works (as in the landing page), so that logged-in users can still see how the app works. 

Fixes #131 