### PR TITLE
Modify the article card design to fix the horizontal alignment 

### DIFF
--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -26,8 +26,6 @@ export default function Article(props) {
   const ratingsCount = usersWithReview.length
 
   const totalRating = articleScores.reduce((prev, current) => {
-    // console.log("prev: " + prev)
-    // console.log("current: " + current._avg.response)
     return prev + current._avg.response! / articleScores.length
   }, 0)
 
@@ -36,7 +34,6 @@ export default function Article(props) {
       className="bg-gray-50 m-3 p-4 border-gray-600 border-2
     flex flex-col  max-w-5xl"
     >
-      <div>
         <div id="article-header" className="flex md:flex-row flex-col">
           <div id="chip-container" className="self-center">
             <Chip label={ratingsCount} className="w-8" />

--- a/app/core/components/Article.tsx
+++ b/app/core/components/Article.tsx
@@ -34,10 +34,11 @@ export default function Article(props) {
       className="bg-gray-50 m-3 p-4 border-gray-600 border-2
     flex flex-col  max-w-5xl"
     >
-        <div id="article-header" className="flex md:flex-row flex-col">
-          <div id="chip-container" className="self-center">
-            <Chip label={ratingsCount} className="w-8" />
-          </div>
+      <div id="article-header" className="flex md:flex-row flex-col">
+        <div id="chip-container" className="self-center">
+          <Chip label={ratingsCount} className="w-8" />
+        </div>
+        <div id="article-metadata" className="w-full flex md:flex-row flex-col  justify-between">
           <div id="title" className="font-semibold inline ml-3">
             <Link href={`/articles/${id}`}>{title}</Link>
           </div>
@@ -46,7 +47,7 @@ export default function Article(props) {
               <FaUser className="inline mr-2" />
               {authorString}
             </div>
-            <div className="article__DOI ml-2 text-gray-700 whitespace-nowrap">
+            <div className="article__DOI ml-2 text-violet-600 whitespace-nowrap">
               <a href={`https://dx.doi.org/${doi}`} rel="noreferrer" target="_blank">
                 <FaBook className="inline mr-2" />
                 {doi}

--- a/app/core/styles/index.css
+++ b/app/core/styles/index.css
@@ -22,3 +22,7 @@
 .aa-Panel {
   z-index: 9999;
 }
+
+.aa-Autocomplete:not(:first-child) {
+  display: none;
+}


### PR DESCRIPTION
This PR modifies the article card design to fix the horizontal alignment issue—fixes #184.

The author and DOI are now justified to the right.

![image](https://user-images.githubusercontent.com/17035406/165860996-0788506b-8e4b-46e2-90c5-fd3a935b46d1.png)